### PR TITLE
[Add] in-line hints

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,6 +5,7 @@ use {
         clip_buffer::{get_default_clipboard, Clipboard},
         completer::{DefaultTabHandler, TabHandler},
         default_emacs_keybindings,
+        hinter::{DefaultHinter, Hinter},
         history::{FileBackedHistory, History, HistoryNavigationQuery},
         keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings, Keybindings},
         line_buffer::{InsertionPoint, LineBuffer},
@@ -88,7 +89,8 @@ impl Reedline {
         let history = Box::new(FileBackedHistory::default());
         let cut_buffer = Box::new(get_default_clipboard());
         let buffer_highlighter = Box::new(DefaultHighlighter::default());
-        let painter = Painter::new(stdout(), buffer_highlighter);
+        let hinter = Box::new(DefaultHinter::default());
+        let painter = Painter::new(stdout(), buffer_highlighter, hinter);
         let mut keybindings_hashmap = HashMap::new();
         keybindings_hashmap.insert(EditMode::Emacs, default_emacs_keybindings());
         keybindings_hashmap.insert(EditMode::ViInsert, default_vi_insert_keybindings());
@@ -108,6 +110,12 @@ impl Reedline {
             tab_handler: Box::new(DefaultTabHandler::default()),
         }
     }
+
+    pub fn with_hinter(mut self, hinter: Box<dyn Hinter>) -> Reedline {
+        self.painter.set_hinter(hinter);
+        self
+    }
+
     pub fn with_tab_handler(mut self, tab_handler: Box<dyn TabHandler>) -> Reedline {
         self.tab_handler = tab_handler;
         self

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -606,8 +606,12 @@ impl Reedline {
         let cursor_position_in_buffer = self.insertion_point().offset;
         let buffer_to_paint = self.insertion_line().to_string();
 
-        self.painter
-            .queue_buffer(buffer_to_paint, prompt_offset, cursor_position_in_buffer)?;
+        self.painter.queue_buffer(
+            buffer_to_paint,
+            prompt_offset,
+            cursor_position_in_buffer,
+            &self.history,
+        )?;
         self.painter.flush()?;
 
         Ok(())
@@ -631,6 +635,7 @@ impl Reedline {
             cursor_position_in_buffer,
             buffer_to_paint,
             terminal_size,
+            &self.history,
         )
 
         // Ok(prompt_offset)
@@ -674,8 +679,12 @@ impl Reedline {
         let cursor_position_in_buffer = self.insertion_point().offset;
 
         if let Some(buffer_to_paint) = self.history.string_at_cursor() {
-            self.painter
-                .queue_buffer(buffer_to_paint, prompt_offset, cursor_position_in_buffer)?;
+            self.painter.queue_buffer(
+                buffer_to_paint,
+                prompt_offset,
+                cursor_position_in_buffer,
+                &self.history,
+            )?;
             self.painter.flush()?;
         }
 

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -1,0 +1,62 @@
+use {
+    crate::{Completer, History},
+    nu_ansi_term::{Color, Style},
+};
+
+pub trait Hinter {
+    fn handle(&mut self, line: &str, pos: usize) -> String;
+}
+
+pub struct DefaultHinter {
+    completer: Option<Box<dyn Completer>>,
+    history: Option<Box<dyn History>>,
+    style: Style,
+}
+
+impl Hinter for DefaultHinter {
+    fn handle(&mut self, line: &str, pos: usize) -> String {
+        if let Some(c) = &self.completer {
+            let completions = c.complete(line, pos);
+
+            if !completions.is_empty() {
+                let mut hint = completions[0].1.clone();
+                let span = completions[0].0;
+                hint.replace_range(0..(span.end - span.start), "");
+
+                self.style.paint(hint).to_string()
+            } else {
+                String::new()
+            }
+        } else if let Some(_) = &self.history {
+            // TODO implement this case
+            String::new()
+        } else {
+            String::new()
+        }
+    }
+}
+
+impl Default for DefaultHinter {
+    fn default() -> Self {
+        DefaultHinter {
+            completer: None,
+            history: None,
+            style: Style::new().fg(Color::LightGray),
+        }
+    }
+}
+
+impl DefaultHinter {
+    pub fn with_completer(mut self, completer: Box<dyn Completer>) -> DefaultHinter {
+        self.completer = Some(completer);
+        self
+    }
+    pub fn with_history(mut self, history: Box<dyn History>) -> DefaultHinter {
+        self.history = Some(history);
+        self
+    }
+    pub fn with_style(mut self, style: Style) -> DefaultHinter {
+        self.style = style;
+        self
+    }
+}

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -19,7 +19,7 @@ pub const HISTORY_SIZE: usize = 1000;
 /// Similar to bash's behavior without HISTTIMEFORMAT.
 /// (See <https://www.gnu.org/software/bash/manual/html_node/Bash-History-Facilities.html>)
 /// If the history is associated to a file all new changes within a given history capacity will be written to disk when History is dropped.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FileBackedHistory {
     capacity: usize,
     entries: VecDeque<String>,

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -19,7 +19,7 @@ pub const HISTORY_SIZE: usize = 1000;
 /// Similar to bash's behavior without HISTTIMEFORMAT.
 /// (See <https://www.gnu.org/software/bash/manual/html_node/Bash-History-Facilities.html>)
 /// If the history is associated to a file all new changes within a given history capacity will be written to disk when History is dropped.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileBackedHistory {
     capacity: usize,
     entries: VecDeque<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,6 @@ mod styled_text;
 
 mod completer;
 pub use completer::{Completer, DefaultCompleter, DefaultTabHandler, Span, TabHandler};
+
+mod hinter;
+pub use hinter::{DefaultHinter, Hinter};

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
         vec![EditCommand::BackspaceWord],
     );
 
-    let history = FileBackedHistory::with_file(5, "history.txt".into())?;
+    let history = Box::new(FileBackedHistory::with_file(5, "history.txt".into())?);
     let commands = vec![
         "test".into(),
         "hello world".into(),
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
     let mut line_editor = Reedline::new()
-        .with_history(Box::new(history))?
+        .with_history(history.clone())?
         .with_edit_mode(if vi_mode {
             reedline::EditMode::ViNormal
         } else {
@@ -58,6 +58,7 @@ fn main() -> Result<()> {
         .with_hinter(Box::new(
             DefaultHinter::default()
                 .with_completer(completer)
+                // .with_history(history)
                 .with_style(Style::new().italic().fg(Color::LightGray)),
         ));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
     let mut line_editor = Reedline::new()
-        .with_history(history.clone())?
+        .with_history(history)?
         .with_edit_mode(if vi_mode {
             reedline::EditMode::ViNormal
         } else {
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
         ))
         .with_hinter(Box::new(
             DefaultHinter::default()
-                .with_completer(completer) // or .with_history(history)
+                .with_completer(completer) // or .with_history()
                 // .with_inside_line()
                 .with_style(Style::new().italic().fg(Color::LightGray)),
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ fn main() -> Result<()> {
         .with_hinter(Box::new(
             DefaultHinter::default()
                 .with_completer(completer)
+                // .with_inside_line()
                 // .with_history(history)
                 .with_style(Style::new().italic().fg(Color::LightGray)),
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,15 @@ use {
         event::{poll, Event, KeyCode, KeyModifiers},
         terminal, Result,
     },
+    nu_ansi_term::{Color, Style},
     reedline::{
-        default_emacs_keybindings, DefaultCompleter, DefaultHighlighter, DefaultPrompt,
-        DefaultTabHandler, EditCommand, FileBackedHistory, Reedline, Signal,
+        default_emacs_keybindings, DefaultCompleter, DefaultHighlighter, DefaultHinter,
+        DefaultPrompt, DefaultTabHandler, EditCommand, FileBackedHistory, Reedline, Signal,
     },
-    std::io::{stdout, Write},
-    std::time::Duration,
+    std::{
+        io::{stdout, Write},
+        time::Duration,
+    },
 };
 
 fn main() -> Result<()> {
@@ -38,6 +41,8 @@ fn main() -> Result<()> {
         "this is reedline crate".into(),
     ];
 
+    let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
+
     let mut line_editor = Reedline::new()
         .with_history(Box::new(history))?
         .with_edit_mode(if vi_mode {
@@ -46,10 +51,15 @@ fn main() -> Result<()> {
             reedline::EditMode::Emacs
         })
         .with_keybindings(keybindings)
-        .with_highlighter(Box::new(DefaultHighlighter::new(commands.clone())))
-        .with_tab_handler(Box::new(DefaultTabHandler::default().with_completer(
-            Box::new(DefaultCompleter::new_with_wordlen(commands, 2)),
-        )));
+        .with_highlighter(Box::new(DefaultHighlighter::new(commands)))
+        .with_tab_handler(Box::new(
+            DefaultTabHandler::default().with_completer(completer.clone()),
+        ))
+        .with_hinter(Box::new(
+            DefaultHinter::default()
+                .with_completer(completer)
+                .with_style(Style::new().italic().fg(Color::LightGray)),
+        ));
 
     let prompt = DefaultPrompt::new(1);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,8 @@ fn main() -> Result<()> {
         ))
         .with_hinter(Box::new(
             DefaultHinter::default()
-                .with_completer(completer)
+                .with_completer(completer) // or .with_history(history)
                 // .with_inside_line()
-                // .with_history(history)
                 .with_style(Style::new().italic().fg(Color::LightGray)),
         ));
 


### PR DESCRIPTION
Implemented features:
 - optional inside line hints
 - customizable hints style
 - hints from completer
 - hints from history

Example:

![Registrazione schermo 2021-07-15 alle 10 28 16](https://user-images.githubusercontent.com/51322105/125755624-630c5730-aea3-432c-b3fd-15d2dfb53a1d.gif)
