### PR TITLE
Fix eclectic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A readline replacement written in Rust
 
-![](https://img.shields.io/github/license/jntrnr/reedline) ![](https://img.shields.io/crates/v/reedline.svg) ![](https://docs.rs/reedline/badge.svg?version=0.1.0) ![](https://img.shields.io/github/repo-size/jntrnr/reedline) ![](https://img.shields.io/tokei/lines/github/jntrnr/reedline) ![](https://img.shields.io/github/commit-activity/m/jntrnr/reedline) ![](https://img.shields.io/github/issues-pr-closed-raw/jntrnr/reedline) ![](https://img.shields.io/discord/601130461678272522) ![](https://img.shields.io/twitch/status/jntrnr?style=social)
+![GitHub](https://img.shields.io/github/license/jntrnr/reedline) ![Crates.io](https://img.shields.io/crates/v/reedline) ![docs.rs](https://img.shields.io/docsrs/reedline) ![Discord](https://img.shields.io/discord/601130461678272522) ![Twitch Status](https://img.shields.io/twitch/status/jntrnr?style=social)
 
 ## Basic example
 
@@ -30,6 +30,7 @@ fn main() {
     }
 }
 ```
+
 ## Integrate with custom Keybindings
 
 ```rust,no_run
@@ -81,7 +82,7 @@ let commands = vec![
   "test".into(),
   "hello world".into(),
   "hello world reedline".into(),
-  "this is reedline crate".into(),
+  "this is the reedline crate".into(),
 ];
 let mut line_editor =
 Reedline::new().with_highlighter(Box::new(DefaultHighlighter::new(commands)));
@@ -98,7 +99,7 @@ let commands = vec![
   "test".into(),
   "hello world".into(),
   "hello world reedline".into(),
-  "this is reedline crate".into(),
+  "this is the reedline crate".into(),
 ];
 let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
@@ -110,7 +111,7 @@ let mut line_editor = Reedline::new().with_tab_handler(Box::new(
 ## Integrate with custom Hinter
 
 ```rust,no_run
-// Create a reedline object with tab completions support
+// Create a reedline object with in-line hint support
 
 //Cargo.toml
 //	[dependencies]
@@ -125,7 +126,7 @@ let commands = vec![
   "test".into(),
   "hello world".into(),
   "hello world reedline".into(),
-  "this is reedline crate".into(),
+  "this is the reedline crate".into(),
 ];
 let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
@@ -152,7 +153,7 @@ let mut line_editor = Reedline::new().with_edit_mode(
 ## Are we prompt yet? (Development status)
 
 This crate is currently under active development in JT's [live-coding streams](https://www.twitch.tv/jntrnr).
-If you want to see a feature, jump by the streams, file an [issue](https://github.com/jonathandturner/reedline/issues) or contribute a [PR](https://github.com/jonathandturner/reedline/pulls)!
+If you want to see a feature, jump by the streams, file an [issue](https://github.com/jntrnr/reedline/issues) or contribute a [PR](https://github.com/jntrnr/reedline/pulls)!
 
 - [x] Basic unicode grapheme aware cursor editing.
 - [x] Configurable prompt
@@ -163,7 +164,9 @@ If you want to see a feature, jump by the streams, file an [issue](https://githu
 - [x] Autocompletion.
 - [ ] Advanced multiline unicode aware editing.
 
-For a more detailed roadmap check out [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
+For a more detailed roadmap check out [TODO.txt](https://github.com/jntrnr/reedline/blob/main/TODO.txt).
+
+Join the vision discussion in the [vision milestone list](https://github.com/jntrnr/reedline/milestone/1) by contributing suggestions or voting.
 
 ### Alternatives
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # A readline replacement written in Rust
 
-![GitHub](https://img.shields.io/github/license/jntrnr/reedline) ![Crates.io](https://img.shields.io/crates/v/reedline) ![docs.rs](https://img.shields.io/docsrs/reedline) ![Discord](https://img.shields.io/discord/601130461678272522) ![Twitch Status](https://img.shields.io/twitch/status/jntrnr?style=social)
+![GitHub](https://img.shields.io/github/license/jntrnr/reedline) 
+[![Crates.io](https://img.shields.io/crates/v/reedline)](https://crates.io/crates/reedline)
+[![docs.rs](https://img.shields.io/docsrs/reedline)](https://docs.rs/reedline/)
+[![Discord](https://img.shields.io/discord/601130461678272522.svg?logo=discord)](https://discord.gg/NtAbbGn)
+[![Twitch Status](https://img.shields.io/twitch/status/jntrnr?style=social)}(https://twitch.tv/jntrnr)
 
 ## Basic example
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/reedline)](https://crates.io/crates/reedline)
 [![docs.rs](https://img.shields.io/docsrs/reedline)](https://docs.rs/reedline/)
 [![Discord](https://img.shields.io/discord/601130461678272522.svg?logo=discord)](https://discord.gg/NtAbbGn)
-[![Twitch Status](https://img.shields.io/twitch/status/jntrnr?style=social)}(https://twitch.tv/jntrnr)
+[![Twitch Status](https://img.shields.io/twitch/status/jntrnr?style=social)](https://twitch.tv/jntrnr)
 
 ## Basic example
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// Valid ways how [`Reedline::read_line()`] can return
+/// Valid ways how [`crate::Reedline::read_line()`] can return
 pub enum Signal {
     /// Entry succeeded with the provided content
     Success(String),
@@ -14,7 +14,7 @@ pub enum Signal {
 
 /// Editing actions which can be mapped to key bindings.
 ///
-/// Executed by [`Reedline::run_edit_commands()`]
+/// Executed by `Reedline::run_edit_commands()`
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum EditCommand {
     MoveToStart,
@@ -48,7 +48,7 @@ pub enum EditCommand {
     ViCommandFragment(char),
 }
 
-/// The edit mode the reedline is currently in
+/// The edit mode [`crate::Reedline`] is currently in. Influences keybindings and prompt.
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 pub enum EditMode {
     Emacs,

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -10,12 +10,12 @@ use super::{
     History,
 };
 
-/// Default size of the [`History`] used when calling [`History::default()`]
+/// Default size of the [`FileBackedHistory`] used when calling [`FileBackedHistory::default()`]
 pub const HISTORY_SIZE: usize = 1000;
 
 /// Stateful history that allows up/down-arrow browsing with an internal cursor.
 ///
-/// Can optionally be associated with a newline separated history file using the [`History::with_file()`] constructor.
+/// Can optionally be associated with a newline separated history file using the [`FileBackedHistory::with_file()`] constructor.
 /// Similar to bash's behavior without HISTTIMEFORMAT.
 /// (See <https://www.gnu.org/software/bash/manual/html_node/Bash-History-Facilities.html>)
 /// If the history is associated to a file all new changes within a given history capacity will be written to disk when History is dropped.
@@ -33,7 +33,7 @@ pub struct FileBackedHistory {
 impl Default for FileBackedHistory {
     /// Creates an in-memory [`History`] with a maximal capacity of [`HISTORY_SIZE`].
     ///
-    /// To create a [`History`] that is synchronized with a file use [`History::with_file()`]
+    /// To create a [`History`] that is synchronized with a file use [`FileBackedHistory::with_file()`]
     fn default() -> Self {
         Self::new(HISTORY_SIZE)
     }
@@ -308,7 +308,7 @@ impl FileBackedHistory {
 }
 
 impl Drop for FileBackedHistory {
-    /// On drop the content of the [`History`] will be written to the file if specified via [`History::with_file()`].
+    /// On drop the content of the [`History`] will be written to the file if specified via [`FileBackedHistory::with_file()`].
     fn drop(&mut self) {
         let _ = self.flush();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! ```
 //! ## Integrate with custom Keybindings
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Configure reedline with custom keybindings
 //!
 //! //Cargo.toml
@@ -53,18 +53,6 @@
 //! let mut line_editor = Reedline::new().with_keybindings(keybindings);
 //! ```
 //!
-//! ## Integrate with custom Edit Mode
-//!
-//! ```rust,no_run
-//! // Create a reedline object with custom edit mode
-//!
-//! use reedline::{EditMode, Reedline};
-//!
-//! let mut line_editor = Reedline::new().with_edit_mode(
-//!   EditMode::ViNormal, // or EditMode::Emacs
-//! );
-//! ```
-//!
 //! ## Integrate with custom History
 //!
 //! ```rust,no_run
@@ -83,7 +71,7 @@
 //!
 //! ## Integrate with custom Highlighter
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with highlighter support
 //!
 //! use reedline::{DefaultHighlighter, Reedline};
@@ -92,7 +80,7 @@
 //!   "test".into(),
 //!   "hello world".into(),
 //!   "hello world reedline".into(),
-//!   "this is reedline crate".into(),
+//!   "this is the reedline crate".into(),
 //! ];
 //! let mut line_editor =
 //! Reedline::new().with_highlighter(Box::new(DefaultHighlighter::new(commands)));
@@ -100,7 +88,7 @@
 //!
 //! ## Integrate with custom Tab-Handler
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with tab completions support
 //!
 //! use reedline::{DefaultCompleter, DefaultTabHandler, Reedline};
@@ -109,7 +97,7 @@
 //!   "test".into(),
 //!   "hello world".into(),
 //!   "hello world reedline".into(),
-//!   "this is reedline crate".into(),
+//!   "this is the reedline crate".into(),
 //! ];
 //! let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 //!
@@ -120,8 +108,8 @@
 //!
 //! ## Integrate with custom Hinter
 //!
-//! ```rust,no_run
-//! // Create a reedline object with tab completions support
+//! ```rust
+//! // Create a reedline object with in-line hint support
 //!
 //! //Cargo.toml
 //! //	[dependencies]
@@ -136,7 +124,7 @@
 //!   "test".into(),
 //!   "hello world".into(),
 //!   "hello world reedline".into(),
-//!   "this is reedline crate".into(),
+//!   "this is the reedline crate".into(),
 //! ];
 //! let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 //!
@@ -148,13 +136,25 @@
 //! ));
 //! ```
 //!
+//! ## Integrate with custom Edit Mode
+//!
+//! ```rust
+//! // Create a reedline object with custom edit mode
+//!
+//! use reedline::{EditMode, Reedline};
+//!
+//! let mut line_editor = Reedline::new().with_edit_mode(
+//!   EditMode::ViNormal, // or EditMode::Emacs or EditMode::ViInsert
+//! );
+//! ```
+//!
 //! ## Are we prompt yet? (Development status)
 //!
 //! This crate is currently under active development
 //! in JT's [live-coding streams](https://www.twitch.tv/jntrnr).
 //! If you want to see a feature, jump by the streams,
-//! file an [issue](https://github.com/jonathandturner/reedline/issues)
-//! or contribute a [PR](https://github.com/jonathandturner/reedline/pulls)!
+//! file an [issue](https://github.com/jntrnr/reedline/issues)
+//! or contribute a [PR](https://github.com/jntrnr/reedline/pulls)!
 //!
 //! - [x] Basic unicode grapheme aware cursor editing.
 //! - [x] Configurable prompt
@@ -165,7 +165,9 @@
 //! - [x] Autocompletion.
 //! - [ ] Advanced multiline unicode aware editing.
 //!
-//! For a more detailed roadmap check out [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
+//! For a more detailed roadmap check out [TODO.txt](https://github.com/jntrnr/reedline/blob/main/TODO.txt).
+//!
+//! Join the vision discussion in the [vision milestone list](https://github.com/jntrnr/reedline/milestone/1) by contributing suggestions or voting.
 //!
 //! ### Alternatives
 //!


### PR DESCRIPTION
* Make `cargo doc` happy again
* Let the `lib.rs` doc test a few constructor examples.
* Fix badges and repo links in the README