### PR TITLE
[Add] CtrlZ (undo) and CtrlG (redo) features

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -566,32 +566,48 @@ impl Reedline {
         // Run the commands over the edit buffer
         for command in &commands {
             match command {
-                EditCommand::MoveToStart => self.move_to_start(),
+                EditCommand::MoveToStart => {
+                    self.move_to_start();
+                    self.line_buffer.set_previous_lines();
+                }
                 EditCommand::MoveToEnd => {
                     self.move_to_end();
+                    self.line_buffer.set_previous_lines();
                 }
-                EditCommand::MoveLeft => self.move_left(),
-                EditCommand::MoveRight => self.move_right(),
+                EditCommand::MoveLeft => {
+                    self.move_left();
+                    self.line_buffer.set_previous_lines();
+                }
+                EditCommand::MoveRight => {
+                    self.move_right();
+                    self.line_buffer.set_previous_lines();
+                }
                 EditCommand::MoveWordLeft => {
                     self.move_word_left();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveWordRight => {
                     self.move_word_right();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::InsertChar(c) => {
                     self.insert_char(*c);
                 }
                 EditCommand::Backspace => {
                     self.backspace();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::Delete => {
                     self.delete();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::BackspaceWord => {
                     self.backspace_word();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::DeleteWord => {
                     self.delete_word();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::Clear => {
                     self.clear();
@@ -616,15 +632,19 @@ impl Reedline {
                 }
                 EditCommand::CutFromStart => {
                     self.cut_from_start();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutToEnd => {
                     self.cut_from_end();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutWordLeft => {
                     self.cut_word_left();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutWordRight => {
                     self.cut_word_right();
+                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::PasteCutBuffer => {
                     self.insert_cut_buffer();
@@ -649,6 +669,12 @@ impl Reedline {
                 }
                 EditCommand::EnterViNormal => {
                     self.enter_vi_normal_mode();
+                }
+                EditCommand::Undo => {
+                    self.line_buffer.undo();
+                }
+                EditCommand::Redo => {
+                    self.line_buffer.redo();
                 }
                 _ => {}
             }
@@ -896,6 +922,7 @@ impl Reedline {
                             {
                                 self.tab_handler.reset_index();
                                 self.run_edit_commands(&[EditCommand::ViCommandFragment(c)]);
+                                self.line_buffer.set_previous_lines();
                             }
                             (KeyModifiers::NONE, KeyCode::Char(c), x)
                             | (KeyModifiers::SHIFT, KeyCode::Char(c), x)
@@ -926,6 +953,7 @@ impl Reedline {
                                 } else {
                                     self.run_edit_commands(&[EditCommand::InsertChar(c)]);
                                 }
+                                self.line_buffer.set_previous_lines();
                             }
                             (KeyModifiers::NONE, KeyCode::Enter, x) if x != EditMode::ViNormal => {
                                 match self.input_mode {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -228,7 +228,7 @@ impl Reedline {
     fn run_history_commands(&mut self, commands: &[EditCommand]) {
         for command in commands {
             match command {
-                EditCommand::InsertChar(c) => {
+                InsertChar(c) => {
                     let navigation = self.history.get_navigation();
                     if let HistoryNavigationQuery::SubstringSearch(mut substring) = navigation {
                         substring.push(*c);
@@ -242,7 +242,7 @@ impl Reedline {
                     }
                     self.history.back();
                 }
-                EditCommand::Backspace => {
+                Backspace => {
                     let navigation = self.history.get_navigation();
 
                     if let HistoryNavigationQuery::SubstringSearch(substring) = navigation {
@@ -568,100 +568,100 @@ impl Reedline {
         // Run the commands over the edit buffer
         for command in &commands {
             match command {
-                EditCommand::MoveToStart => {
+                MoveToStart => {
                     self.move_to_start();
                 }
-                EditCommand::MoveToEnd => {
+                MoveToEnd => {
                     self.move_to_end();
                 }
-                EditCommand::MoveLeft => {
+                MoveLeft => {
                     self.move_left();
                 }
-                EditCommand::MoveRight => {
+                MoveRight => {
                     self.move_right();
                 }
-                EditCommand::MoveWordLeft => {
+                MoveWordLeft => {
                     self.move_word_left();
                 }
-                EditCommand::MoveWordRight => {
+                MoveWordRight => {
                     self.move_word_right();
                 }
-                EditCommand::InsertChar(c) => {
+                InsertChar(c) => {
                     self.insert_char(*c);
                 }
-                EditCommand::Backspace => {
+                Backspace => {
                     self.backspace();
                 }
-                EditCommand::Delete => {
+                Delete => {
                     self.delete();
                 }
-                EditCommand::BackspaceWord => {
+                BackspaceWord => {
                     self.backspace_word();
                 }
-                EditCommand::DeleteWord => {
+                DeleteWord => {
                     self.delete_word();
                 }
-                EditCommand::Clear => {
+                Clear => {
                     self.clear();
                 }
-                EditCommand::AppendToHistory => {
+                AppendToHistory => {
                     self.append_to_history();
                 }
-                EditCommand::PreviousHistory => {
+                PreviousHistory => {
                     self.previous_history();
                 }
-                EditCommand::NextHistory => {
+                NextHistory => {
                     self.next_history();
                 }
-                EditCommand::Up => {
+                Up => {
                     self.up_command();
                 }
-                EditCommand::Down => {
+                Down => {
                     self.down_command();
                 }
-                EditCommand::SearchHistory => {
+                SearchHistory => {
                     self.search_history();
                 }
-                EditCommand::CutFromStart => {
+                CutFromStart => {
                     self.cut_from_start();
                 }
-                EditCommand::CutToEnd => {
+                CutToEnd => {
                     self.cut_from_end();
                 }
-                EditCommand::CutWordLeft => {
+                CutWordLeft => {
                     self.cut_word_left();
                 }
-                EditCommand::CutWordRight => {
+                CutWordRight => {
                     self.cut_word_right();
                 }
-                EditCommand::PasteCutBuffer => {
+                PasteCutBuffer => {
                     self.insert_cut_buffer();
                 }
-                EditCommand::UppercaseWord => {
+                UppercaseWord => {
                     self.uppercase_word();
                 }
-                EditCommand::LowercaseWord => {
+                LowercaseWord => {
                     self.lowercase_word();
                 }
-                EditCommand::CapitalizeChar => {
+                CapitalizeChar => {
                     self.capitalize_char();
                 }
-                EditCommand::SwapWords => {
+                SwapWords => {
                     self.swap_words();
                 }
-                EditCommand::SwapGraphemes => {
+                SwapGraphemes => {
                     self.swap_graphemes();
                 }
-                EditCommand::EnterViInsert => {
+                EnterViInsert => {
                     self.enter_vi_insert_mode();
                 }
-                EditCommand::EnterViNormal => {
+                EnterViNormal => {
                     self.enter_vi_normal_mode();
                 }
-                EditCommand::Undo => {
+                Undo => {
                     self.line_buffer.undo();
                 }
-                EditCommand::Redo => {
+                Redo => {
                     self.line_buffer.redo();
                 }
                 _ => {}
@@ -933,7 +933,7 @@ impl Reedline {
                                 if x == EditMode::ViNormal =>
                             {
                                 self.tab_handler.reset_index();
-                                self.run_edit_commands(&[EditCommand::ViCommandFragment(c)]);
+                                self.run_edit_commands(&[ViCommandFragment(c)]);
                                 self.line_buffer.set_previous_lines();
                             }
                             (KeyModifiers::NONE, KeyCode::Char(c), x)
@@ -948,7 +948,7 @@ impl Reedline {
                                 };
                                 if self.maybe_wrap(terminal_size.0, line_start, c) {
                                     let (original_column, original_row) = position()?;
-                                    self.run_edit_commands(&[EditCommand::InsertChar(c)]);
+                                    self.run_edit_commands(&[InsertChar(c)]);
 
                                     self.buffer_paint(prompt_offset)?;
 
@@ -963,7 +963,7 @@ impl Reedline {
                                         prompt_offset.1 -= 1;
                                     }
                                 } else {
-                                    self.run_edit_commands(&[EditCommand::InsertChar(c)]);
+                                    self.run_edit_commands(&[InsertChar(c)]);
                                 }
                                 self.line_buffer.set_previous_lines();
                             }
@@ -972,10 +972,7 @@ impl Reedline {
                                     InputMode::Regular => {
                                         let buffer = self.insertion_line().to_string();
 
-                                        self.run_edit_commands(&[
-                                            EditCommand::AppendToHistory,
-                                            EditCommand::Clear,
-                                        ]);
+                                        self.run_edit_commands(&[AppendToHistory, Clear]);
                                         self.print_crlf()?;
                                         self.tab_handler.reset_index();
                                         self.line_buffer.reset_olds();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -685,7 +685,7 @@ impl Reedline {
             ]
             .contains(command)
             {
-                self.line_buffer.set_previous_lines();
+                self.line_buffer.set_previous_lines(true);
             }
         }
     }
@@ -934,7 +934,7 @@ impl Reedline {
                             {
                                 self.tab_handler.reset_index();
                                 self.run_edit_commands(&[ViCommandFragment(c)]);
-                                self.line_buffer.set_previous_lines();
+                                self.line_buffer.set_previous_lines(false);
                             }
                             (KeyModifiers::NONE, KeyCode::Char(c), x)
                             | (KeyModifiers::SHIFT, KeyCode::Char(c), x)
@@ -965,7 +965,7 @@ impl Reedline {
                                 } else {
                                     self.run_edit_commands(&[InsertChar(c)]);
                                 }
-                                self.line_buffer.set_previous_lines();
+                                self.line_buffer.set_previous_lines(false);
                             }
                             (KeyModifiers::NONE, KeyCode::Enter, x) if x != EditMode::ViNormal => {
                                 match self.input_mode {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -11,7 +11,9 @@ use {
         line_buffer::{InsertionPoint, LineBuffer},
         painter::Painter,
         prompt::{PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode},
-        DefaultHighlighter, EditCommand, EditMode, Highlighter, Prompt, Signal, ViEngine,
+        DefaultHighlighter,
+        EditCommand::{self, *},
+        EditMode, Highlighter, Prompt, Signal, ViEngine,
     },
     crossterm::{
         cursor::position,
@@ -568,46 +570,36 @@ impl Reedline {
             match command {
                 EditCommand::MoveToStart => {
                     self.move_to_start();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveToEnd => {
                     self.move_to_end();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveLeft => {
                     self.move_left();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveRight => {
                     self.move_right();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveWordLeft => {
                     self.move_word_left();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::MoveWordRight => {
                     self.move_word_right();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::InsertChar(c) => {
                     self.insert_char(*c);
                 }
                 EditCommand::Backspace => {
                     self.backspace();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::Delete => {
                     self.delete();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::BackspaceWord => {
                     self.backspace_word();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::DeleteWord => {
                     self.delete_word();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::Clear => {
                     self.clear();
@@ -632,19 +624,15 @@ impl Reedline {
                 }
                 EditCommand::CutFromStart => {
                     self.cut_from_start();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutToEnd => {
                     self.cut_from_end();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutWordLeft => {
                     self.cut_word_left();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::CutWordRight => {
                     self.cut_word_right();
-                    self.line_buffer.set_previous_lines();
                 }
                 EditCommand::PasteCutBuffer => {
                     self.insert_cut_buffer();
@@ -677,6 +665,27 @@ impl Reedline {
                     self.line_buffer.redo();
                 }
                 _ => {}
+            }
+
+            if [
+                MoveToEnd,
+                MoveToStart,
+                MoveLeft,
+                MoveRight,
+                MoveWordLeft,
+                MoveWordRight,
+                Backspace,
+                Delete,
+                BackspaceWord,
+                DeleteWord,
+                CutFromStart,
+                CutToEnd,
+                CutWordLeft,
+                CutWordRight,
+            ]
+            .contains(command)
+            {
+                self.line_buffer.set_previous_lines();
             }
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -11,9 +11,7 @@ use {
         line_buffer::{InsertionPoint, LineBuffer},
         painter::Painter,
         prompt::{PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode},
-        DefaultHighlighter,
-        EditCommand::{self, *},
-        EditMode, Highlighter, Prompt, Signal, ViEngine,
+        DefaultHighlighter, EditCommand, EditMode, Highlighter, Prompt, Signal, ViEngine,
     },
     crossterm::{
         cursor::position,
@@ -228,7 +226,7 @@ impl Reedline {
     fn run_history_commands(&mut self, commands: &[EditCommand]) {
         for command in commands {
             match command {
-                InsertChar(c) => {
+                EditCommand::InsertChar(c) => {
                     let navigation = self.history.get_navigation();
                     if let HistoryNavigationQuery::SubstringSearch(mut substring) = navigation {
                         substring.push(*c);
@@ -242,7 +240,7 @@ impl Reedline {
                     }
                     self.history.back();
                 }
-                Backspace => {
+                EditCommand::Backspace => {
                     let navigation = self.history.get_navigation();
 
                     if let HistoryNavigationQuery::SubstringSearch(substring) = navigation {
@@ -568,120 +566,120 @@ impl Reedline {
         // Run the commands over the edit buffer
         for command in &commands {
             match command {
-                MoveToStart => {
+                EditCommand::MoveToStart => {
                     self.move_to_start();
                 }
-                MoveToEnd => {
+                EditCommand::MoveToEnd => {
                     self.move_to_end();
                 }
-                MoveLeft => {
+                EditCommand::MoveLeft => {
                     self.move_left();
                 }
-                MoveRight => {
+                EditCommand::MoveRight => {
                     self.move_right();
                 }
-                MoveWordLeft => {
+                EditCommand::MoveWordLeft => {
                     self.move_word_left();
                 }
-                MoveWordRight => {
+                EditCommand::MoveWordRight => {
                     self.move_word_right();
                 }
-                InsertChar(c) => {
+                EditCommand::InsertChar(c) => {
                     self.insert_char(*c);
                 }
-                Backspace => {
+                EditCommand::Backspace => {
                     self.backspace();
                 }
-                Delete => {
+                EditCommand::Delete => {
                     self.delete();
                 }
-                BackspaceWord => {
+                EditCommand::BackspaceWord => {
                     self.backspace_word();
                 }
-                DeleteWord => {
+                EditCommand::DeleteWord => {
                     self.delete_word();
                 }
-                Clear => {
+                EditCommand::Clear => {
                     self.clear();
                 }
-                AppendToHistory => {
+                EditCommand::AppendToHistory => {
                     self.append_to_history();
                 }
-                PreviousHistory => {
+                EditCommand::PreviousHistory => {
                     self.previous_history();
                 }
-                NextHistory => {
+                EditCommand::NextHistory => {
                     self.next_history();
                 }
-                Up => {
+                EditCommand::Up => {
                     self.up_command();
                 }
-                Down => {
+                EditCommand::Down => {
                     self.down_command();
                 }
-                SearchHistory => {
+                EditCommand::SearchHistory => {
                     self.search_history();
                 }
-                CutFromStart => {
+                EditCommand::CutFromStart => {
                     self.cut_from_start();
                 }
-                CutToEnd => {
+                EditCommand::CutToEnd => {
                     self.cut_from_end();
                 }
-                CutWordLeft => {
+                EditCommand::CutWordLeft => {
                     self.cut_word_left();
                 }
-                CutWordRight => {
+                EditCommand::CutWordRight => {
                     self.cut_word_right();
                 }
-                PasteCutBuffer => {
+                EditCommand::PasteCutBuffer => {
                     self.insert_cut_buffer();
                 }
-                UppercaseWord => {
+                EditCommand::UppercaseWord => {
                     self.uppercase_word();
                 }
-                LowercaseWord => {
+                EditCommand::LowercaseWord => {
                     self.lowercase_word();
                 }
-                CapitalizeChar => {
+                EditCommand::CapitalizeChar => {
                     self.capitalize_char();
                 }
-                SwapWords => {
+                EditCommand::SwapWords => {
                     self.swap_words();
                 }
-                SwapGraphemes => {
+                EditCommand::SwapGraphemes => {
                     self.swap_graphemes();
                 }
-                EnterViInsert => {
+                EditCommand::EnterViInsert => {
                     self.enter_vi_insert_mode();
                 }
-                EnterViNormal => {
+                EditCommand::EnterViNormal => {
                     self.enter_vi_normal_mode();
                 }
-                Undo => {
+                EditCommand::Undo => {
                     self.line_buffer.undo();
                 }
-                Redo => {
+                EditCommand::Redo => {
                     self.line_buffer.redo();
                 }
                 _ => {}
             }
 
             if [
-                MoveToEnd,
-                MoveToStart,
-                MoveLeft,
-                MoveRight,
-                MoveWordLeft,
-                MoveWordRight,
-                Backspace,
-                Delete,
-                BackspaceWord,
-                DeleteWord,
-                CutFromStart,
-                CutToEnd,
-                CutWordLeft,
-                CutWordRight,
+                EditCommand::MoveToEnd,
+                EditCommand::MoveToStart,
+                EditCommand::MoveLeft,
+                EditCommand::MoveRight,
+                EditCommand::MoveWordLeft,
+                EditCommand::MoveWordRight,
+                EditCommand::Backspace,
+                EditCommand::Delete,
+                EditCommand::BackspaceWord,
+                EditCommand::DeleteWord,
+                EditCommand::CutFromStart,
+                EditCommand::CutToEnd,
+                EditCommand::CutWordLeft,
+                EditCommand::CutWordRight,
             ]
             .contains(command)
             {
@@ -933,7 +931,7 @@ impl Reedline {
                                 if x == EditMode::ViNormal =>
                             {
                                 self.tab_handler.reset_index();
-                                self.run_edit_commands(&[ViCommandFragment(c)]);
+                                self.run_edit_commands(&[EditCommand::ViCommandFragment(c)]);
                                 self.line_buffer.set_previous_lines(false);
                             }
                             (KeyModifiers::NONE, KeyCode::Char(c), x)
@@ -948,7 +946,7 @@ impl Reedline {
                                 };
                                 if self.maybe_wrap(terminal_size.0, line_start, c) {
                                     let (original_column, original_row) = position()?;
-                                    self.run_edit_commands(&[InsertChar(c)]);
+                                    self.run_edit_commands(&[EditCommand::InsertChar(c)]);
 
                                     self.buffer_paint(prompt_offset)?;
 
@@ -963,7 +961,7 @@ impl Reedline {
                                         prompt_offset.1 -= 1;
                                     }
                                 } else {
-                                    self.run_edit_commands(&[InsertChar(c)]);
+                                    self.run_edit_commands(&[EditCommand::InsertChar(c)]);
                                 }
                                 self.line_buffer.set_previous_lines(false);
                             }
@@ -972,7 +970,10 @@ impl Reedline {
                                     InputMode::Regular => {
                                         let buffer = self.insertion_line().to_string();
 
-                                        self.run_edit_commands(&[AppendToHistory, Clear]);
+                                        self.run_edit_commands(&[
+                                            EditCommand::AppendToHistory,
+                                            EditCommand::Clear,
+                                        ]);
                                         self.print_crlf()?;
                                         self.tab_handler.reset_index();
                                         self.line_buffer.reset_olds();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -899,6 +899,7 @@ impl Reedline {
                             (KeyModifiers::CONTROL, KeyCode::Char('d'), _) => {
                                 self.tab_handler.reset_index();
                                 if self.line_buffer.is_empty() {
+                                    self.line_buffer.reset_olds();
                                     return Ok(Signal::CtrlD);
                                 } else if let Some(binding) = self.find_keybinding(modifiers, code)
                                 {
@@ -910,10 +911,12 @@ impl Reedline {
                                 if let Some(binding) = self.find_keybinding(modifiers, code) {
                                     self.run_edit_commands(&binding);
                                 }
+                                self.line_buffer.reset_olds();
                                 return Ok(Signal::CtrlC);
                             }
                             (KeyModifiers::CONTROL, KeyCode::Char('l'), EditMode::Emacs) => {
                                 self.tab_handler.reset_index();
+                                self.line_buffer.reset_olds();
                                 return Ok(Signal::CtrlL);
                             }
                             (KeyModifiers::NONE, KeyCode::Char(c), x)
@@ -966,6 +969,7 @@ impl Reedline {
                                         ]);
                                         self.print_crlf()?;
                                         self.tab_handler.reset_index();
+                                        self.line_buffer.reset_olds();
 
                                         return Ok(Signal::Success(buffer));
                                     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -48,6 +48,8 @@ pub enum EditCommand {
     EnterViNormal,
     EnterViInsert,
     ViCommandFragment(char),
+    Undo,
+    Redo,
 }
 
 /// The edit mode [`crate::Reedline`] is currently in. Influences keybindings and prompt.

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -15,7 +15,7 @@ pub enum Signal {
 /// Editing actions which can be mapped to key bindings.
 ///
 /// Executed by `Reedline::run_edit_commands()`
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum EditCommand {
     MoveToStart,
     MoveToEnd,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -106,6 +106,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
     let mut keybindings = Keybindings::new();
 
     // CTRL
+    keybindings.add_binding(KeyModifiers::CONTROL, Char('y'), vec![EditCommand::Redo]);
+    keybindings.add_binding(KeyModifiers::CONTROL, Char('z'), vec![EditCommand::Undo]);
     keybindings.add_binding(KeyModifiers::CONTROL, Char('d'), vec![EditCommand::Delete]);
     keybindings.add_binding(
         KeyModifiers::CONTROL,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -106,7 +106,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     let mut keybindings = Keybindings::new();
 
     // CTRL
-    keybindings.add_binding(KeyModifiers::CONTROL, Char('y'), vec![EditCommand::Redo]);
+    keybindings.add_binding(KeyModifiers::CONTROL, Char('g'), vec![EditCommand::Redo]);
     keybindings.add_binding(KeyModifiers::CONTROL, Char('z'), vec![EditCommand::Undo]);
     keybindings.add_binding(KeyModifiers::CONTROL, Char('d'), vec![EditCommand::Delete]);
     keybindings.add_binding(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,26 +8,24 @@
 //!
 //! use reedline::{DefaultPrompt, Reedline, Signal};
 //!
-//! fn main() {
-//!     let mut line_editor = Reedline::new();
-//!     let prompt = DefaultPrompt::default();
+//!  let mut line_editor = Reedline::new();
+//!  let prompt = DefaultPrompt::default();
 //!
-//!     loop {
-//!         let sig = line_editor.read_line(&prompt).unwrap();
-//!         match sig {
-//!             Signal::Success(buffer) => {
-//!                 println!("We processed: {}", buffer);
-//!             }
-//!             Signal::CtrlD | Signal::CtrlC => {
-//!                 line_editor.print_crlf().unwrap();
-//!                 break;
-//!             }
-//!             Signal::CtrlL => {
-//!                 line_editor.clear_screen().unwrap();
-//!             }
-//!         }
-//!     }
-//! }
+//!  loop {
+//!      let sig = line_editor.read_line(&prompt).unwrap();
+//!      match sig {
+//!          Signal::Success(buffer) => {
+//!              println!("We processed: {}", buffer);
+//!          }
+//!          Signal::CtrlD | Signal::CtrlC => {
+//!              line_editor.print_crlf().unwrap();
+//!              break;
+//!          }
+//!          Signal::CtrlL => {
+//!              line_editor.clear_screen().unwrap();
+//!          }
+//!      }
+//!  }
 //! ```
 //! ## Integrate with custom Keybindings
 //!
@@ -35,8 +33,8 @@
 //! // Configure reedline with custom keybindings
 //!
 //! //Cargo.toml
-//! //	[dependencies]
-//! //	crossterm = "*"
+//! //    [dependencies]
+//! //    crossterm = "*"
 //!
 //! use {
 //!   crossterm::event::{KeyCode, KeyModifiers},
@@ -45,9 +43,9 @@
 //!
 //! let mut keybindings = default_emacs_keybindings();
 //! keybindings.add_binding(
-//! 	KeyModifiers::ALT,
-//!   KeyCode::Char('m'),
-//!   vec![EditCommand::BackspaceWord],
+//!     KeyModifiers::ALT,
+//!     KeyCode::Char('m'),
+//!     vec![EditCommand::BackspaceWord],
 //! );
 //!
 //! let mut line_editor = Reedline::new().with_keybindings(keybindings);
@@ -61,12 +59,12 @@
 //! use reedline::{FileBackedHistory, Reedline};
 //!
 //! let history = Box::new(
-//!   FileBackedHistory::with_file(5, "history.txt".into())
-//!   	.expect("Error configuring history with file"),
+//!     FileBackedHistory::with_file(5, "history.txt".into())
+//!         .expect("Error configuring history with file"),
 //! );
 //! let mut line_editor = Reedline::new()
-//! 	.with_history(history)
-//! 	.expect("Error configuring reedline with history");
+//!     .with_history(history)
+//!     .expect("Error configuring reedline with history");
 //! ```
 //!
 //! ## Integrate with custom Highlighter
@@ -112,8 +110,8 @@
 //! // Create a reedline object with in-line hint support
 //!
 //! //Cargo.toml
-//! //	[dependencies]
-//! //	nu-ansi-term = "*"
+//! //    [dependencies]
+//! //    nu-ansi-term = "*"
 //!
 //! use {
 //!   nu_ansi_term::{Color, Style},

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -46,6 +46,12 @@ impl LineBuffer {
         }
     }
 
+    pub fn reset_olds(&mut self) {
+        self.old_lines = vec![vec![String::new()]];
+        self.old_insertion_point = vec![InsertionPoint::new()];
+        self.index_undo = 2;
+    }
+
     fn get_index_undo(&self) -> usize {
         if let Some(c) = self.old_lines.len().checked_sub(self.index_undo) {
             c

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -72,10 +72,18 @@ impl LineBuffer {
         Some(())
     }
 
-    pub fn set_previous_lines(&mut self) {
+    pub fn set_previous_lines(&mut self) -> Option<()> {
         self.reset_index_undo();
+        if self.old_lines.len() > 1
+            && self.old_lines.last()?.concat().trim().split(' ').count()
+                == self.lines.concat().trim().split(' ').count()
+        {
+            self.old_lines.pop();
+            self.old_insertion_point.pop();
+        }
         self.old_lines.push(self.lines.clone());
         self.old_insertion_point.push(self.insertion_point());
+        Some(())
     }
 
     pub fn reset_index_undo(&mut self) {

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -78,11 +78,12 @@ impl LineBuffer {
         Some(())
     }
 
-    pub fn set_previous_lines(&mut self) -> Option<()> {
+    pub fn set_previous_lines(&mut self, is_after_action: bool) -> Option<()> {
         self.reset_index_undo();
         if self.old_lines.len() > 1
             && self.old_lines.last()?.concat().trim().split(' ').count()
                 == self.lines.concat().trim().split(' ').count()
+            && !is_after_action
         {
             self.old_lines.pop();
             self.old_insertion_point.pop();


### PR DESCRIPTION
**Simple undo and redo**
![Registrazione schermo 2021-07-19 alle 22 16 48](https://user-images.githubusercontent.com/51322105/126221837-f0cb18dc-1dc3-485b-a822-33792a622d2a.gif)

**Cursor position restored after CtrlA-CtrlE with undo and redo**
![Registrazione schermo 2021-07-19 alle 22 19 37](https://user-images.githubusercontent.com/51322105/126222113-4dccf796-49f4-4c78-921f-cfb15d9e339f.gif)

**Undo and redo with middle line changes**
![Registrazione schermo 2021-07-19 alle 22 21 58](https://user-images.githubusercontent.com/51322105/126222514-a8299cd3-d63d-456b-a078-868d8b10cec9.gif)


