### PR TITLE
Add multiline support

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -23,6 +23,8 @@ pub enum EditCommand {
     MoveRight,
     MoveWordLeft,
     MoveWordRight,
+    Up,
+    Down,
     InsertChar(char),
     Backspace,
     Delete,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -181,6 +181,11 @@ pub fn default_emacs_keybindings() -> Keybindings {
     );
     keybindings.add_binding(
         KeyModifiers::ALT,
+        Enter,
+        vec![EditCommand::InsertChar('\n')],
+    );
+    keybindings.add_binding(
+        KeyModifiers::ALT,
         Char('b'),
         vec![EditCommand::MoveWordLeft],
     );
@@ -227,8 +232,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
     keybindings.add_binding(KeyModifiers::NONE, Delete, vec![EditCommand::Delete]);
     keybindings.add_binding(KeyModifiers::NONE, Home, vec![EditCommand::MoveToStart]);
     keybindings.add_binding(KeyModifiers::NONE, End, vec![EditCommand::MoveToEnd]);
-    keybindings.add_binding(KeyModifiers::NONE, Up, vec![EditCommand::PreviousHistory]);
-    keybindings.add_binding(KeyModifiers::NONE, Down, vec![EditCommand::NextHistory]);
+    keybindings.add_binding(KeyModifiers::NONE, Up, vec![EditCommand::Up]);
+    keybindings.add_binding(KeyModifiers::NONE, Down, vec![EditCommand::Down]);
     keybindings.add_binding(KeyModifiers::NONE, Left, vec![EditCommand::MoveLeft]);
     keybindings.add_binding(KeyModifiers::NONE, Right, vec![EditCommand::MoveRight]);
 


### PR DESCRIPTION
This adds basic multiline support. To do so, we extend the logic for up/down to check to see if we're in a multiline situation.

For up:
If we're at the top of a multiline, we go to this previous history. If we're below the top, we count off what column we're on, move up a line, then count back to that column.

Down is the same, but moving to the next line instead of previous line.