### PR TITLE
Fix the history behavior (#94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target/
-
+history.txt

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -780,7 +780,8 @@ impl Reedline {
 
             match self.history.string_at_cursor() {
                 Some(string) => {
-                    self.painter.queue_history_results(&string, string.len())?;
+                    self.painter
+                        .queue_history_search_result(&string, string.len())?;
                     self.painter.flush()?;
                 }
 
@@ -952,18 +953,22 @@ impl Reedline {
                 if self.insertion_line().to_string().is_empty() {
                     self.tab_handler.reset_index();
                 }
-                if self.input_mode == InputMode::HistorySearch {
-                    self.history_search_paint(prompt)?;
-                } else if self.input_mode == InputMode::HistoryTraversal {
-                    self.history_traversal_paint(prompt_offset)?;
-                } else if self.need_full_repaint {
-                    prompt_offset = self.full_repaint(prompt, prompt_origin, terminal_size)?;
-                    self.need_full_repaint = false;
-                } else {
-                    self.buffer_paint(prompt_offset)?;
-                }
             } else {
+                // No key event: 
+                // Repaint the prompt for the clock
+                self.need_full_repaint = true;
+            }
+
+            // Repainting
+            if self.input_mode == InputMode::HistorySearch {
+                self.history_search_paint(prompt)?;
+            } else if self.input_mode == InputMode::HistoryTraversal {
+                self.history_traversal_paint(prompt_offset)?;
+            } else if self.need_full_repaint {
                 prompt_offset = self.full_repaint(prompt, prompt_origin, terminal_size)?;
+                self.need_full_repaint = false;
+            } else {
+                self.buffer_paint(prompt_offset)?;
             }
         }
     }

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,8 +1,10 @@
 use std::collections::vec_deque::Iter;
 
+use crate::line_buffer::LineBuffer;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HistoryNavigationQuery {
-    Normal,
+    Normal(LineBuffer),
     PrefixSearch(String),
     SubstringSearch(String),
     // Suffix Search

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -90,7 +90,7 @@ impl HistoryView for FileBackedHistory {
     fn forward(&mut self) {
         match self.query.clone() {
             HistoryNavigationQuery::Normal => {
-                if (self.cursor as isize) < self.entries.len() as isize - 1 {
+                if self.cursor < self.entries.len() {
                     self.cursor += 1;
                 }
             }
@@ -104,11 +104,10 @@ impl HistoryView for FileBackedHistory {
     }
 
     fn string_at_cursor(&self) -> Option<String> {
-        if self.entries.is_empty() {
-            return None;
-        }
-
-        let entry = self.entries[self.cursor].to_string();
+        let entry = match self.entries.get(self.cursor) {
+            Some(entry) => entry.to_owned(),
+            None => return None,
+        };
 
         match self.query.clone() {
             HistoryNavigationQuery::Normal => Some(entry),
@@ -299,11 +298,7 @@ impl FileBackedHistory {
 
     /// Reset the internal browsing cursor
     fn reset_cursor(&mut self) {
-        if self.entries.is_empty() {
-            self.cursor = 0
-        } else {
-            self.cursor = self.entries.len() - 1;
-        }
+        self.cursor = self.entries.len();
     }
 }
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -107,32 +107,6 @@ impl HistoryView for FileBackedHistory {
 
     fn string_at_cursor(&self) -> Option<String> {
         self.entries.get(self.cursor).cloned()
-
-        // let entry = match self.entries.get(self.cursor) {
-        //     Some(entry) => entry.to_owned(),
-        //     None => return None,
-        // };
-
-        // match self.query.clone() {
-        //     HistoryNavigationQuery::Normal => Some(entry),
-        //     HistoryNavigationQuery::PrefixSearch(prefix) => {
-        //         if entry.starts_with(&prefix) {
-        //             Some(entry)
-        //         } else {
-        //             unreachable!()
-        //         }
-        //     }
-        //     HistoryNavigationQuery::SubstringSearch(substring) => {
-        //         if substring.is_empty() {
-        //             unreachable!()
-        //         }
-        //         if entry.contains(&substring) {
-        //             Some(entry)
-        //         } else {
-        //             unreachable!()
-        //         }
-        //     }
-        // }
     }
 
     fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -20,7 +20,7 @@ impl Default for InsertionPoint {
 }
 
 /// In memory representation of the entered line(s) to facilitate cursor based editing.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LineBuffer {
     lines: Vec<String>,
     insertion_point: InsertionPoint,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,12 +33,16 @@ fn main() -> Result<()> {
         vec![EditCommand::BackspaceWord],
     );
 
-    let history = Box::new(FileBackedHistory::with_file(5, "history.txt".into())?);
+    let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
         "test".into(),
+        "clear".into(),
+        "exit".into(),
+        "history".into(),
+        "logout".into(),
         "hello world".into(),
         "hello world reedline".into(),
-        "this is reedline crate".into(),
+        "this is the reedline crate".into(),
     ];
 
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -187,7 +187,11 @@ impl Painter {
         Ok(())
     }
 
-    pub fn queue_history_results(&mut self, history_result: &str, offset: usize) -> Result<()> {
+    pub fn queue_history_search_result(
+        &mut self,
+        history_result: &str,
+        offset: usize,
+    ) -> Result<()> {
         self.stdout
             .queue(Print(&history_result[..offset]))?
             .queue(SavePosition)?


### PR DESCRIPTION
- [x] Repaint mode switching after the 1sec case
- [x] Back to history cursor with len for not used -> fixes the skipping the
most recent
- [x] Traversal and prefix search now work as expected
- [x] Ctrl-R working (not super elegant but browsable)

Closes #94 