### PR TITLE
Pull undo redo to editor

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -16,7 +16,7 @@ impl Default for Editor {
             line_buffer: LineBuffer::new(),
             cut_buffer: Box::new(get_default_clipboard()),
 
-            // Note: Using list-zipper we can reduce these to one fild
+            // Note: Using list-zipper we can reduce these to one field
             edits: vec![],
             index_undo: 2,
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,16 +1,15 @@
-use crate::{core_editor::LineBuffer, text_manipulation};
-
 use {
     crate::{
         completer::{ComplationActionHandler, DefaultCompletionActionHandler},
-        core_editor::{get_default_clipboard, Editor},
+        core_editor::Editor,
         default_emacs_keybindings,
         hinter::{DefaultHinter, Hinter},
         history::{FileBackedHistory, History, HistoryNavigationQuery},
         keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings, Keybindings},
         painter::Painter,
         prompt::{PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode},
-        DefaultHighlighter, EditCommand, EditMode, Highlighter, Prompt, Signal, ViEngine,
+        text_manipulation, DefaultHighlighter, EditCommand, EditMode, Highlighter, Prompt, Signal,
+        ViEngine,
     },
     crossterm::{
         cursor::position,
@@ -92,7 +91,7 @@ impl Reedline {
         keybindings_hashmap.insert(EditMode::ViNormal, default_vi_normal_keybindings());
 
         Reedline {
-            editor: Editor::new(LineBuffer::new(), Box::new(get_default_clipboard())),
+            editor: Editor::default(),
             history,
             input_mode: InputMode::Regular,
             painter,


### PR DESCRIPTION
I wanted to create this on the branch that I have requested to merge but looks like I can't really do that as that branch does not exist in this repo. (Sigh: github should really allow for creating PRs over other PRs :P)

Anyway, this is a simplification of pulling out the undo and redo functionality into the editor struct whilst also simplifying it a bit.

**NOTE TO Reviewers: #128 does most of the work on which this build on. Only take a look at the last commit in this PR**