### PR TITLE
Pull some events from EditCommand to ReedlineEvent

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -36,7 +36,7 @@ impl EditMode for Emacs {
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => {
                     if let Some(binding) = self.keybindings.find_binding(modifiers, code) {
-                        ReedlineEvent::Edit(binding)
+                        binding
                     } else {
                         ReedlineEvent::Edit(vec![])
                     }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -31,7 +31,7 @@ impl EditMode for Emacs {
                 (KeyModifiers::CONTROL, KeyCode::Char('l')) => ReedlineEvent::ClearScreen,
                 (KeyModifiers::NONE, KeyCode::Char(c))
                 | (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
-                    ReedlineEvent::EditInsert(EditCommand::InsertChar(c))
+                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
                 }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => {

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -1,3 +1,5 @@
+use crate::enums::ReedlineEvent;
+
 use {
     crate::EditCommand,
     crossterm::event::{KeyCode, KeyModifiers},
@@ -8,7 +10,7 @@ use {
 pub struct Keybinding {
     modifier: KeyModifiers,
     key_code: KeyCode,
-    edit_commands: Vec<EditCommand>,
+    command: ReedlineEvent,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -31,23 +33,19 @@ impl Keybindings {
         &mut self,
         modifier: KeyModifiers,
         key_code: KeyCode,
-        edit_commands: Vec<EditCommand>,
+        command: ReedlineEvent,
     ) {
         self.bindings.push(Keybinding {
             modifier,
             key_code,
-            edit_commands,
+            command,
         });
     }
 
-    pub fn find_binding(
-        &self,
-        modifier: KeyModifiers,
-        key_code: KeyCode,
-    ) -> Option<Vec<EditCommand>> {
+    pub fn find_binding(&self, modifier: KeyModifiers, key_code: KeyCode) -> Option<ReedlineEvent> {
         for binding in &self.bindings {
             if binding.modifier == modifier && binding.key_code == key_code {
-                return Some(binding.edit_commands.clone());
+                return Some(binding.command.clone());
             }
         }
 
@@ -55,145 +53,59 @@ impl Keybindings {
     }
 }
 
+fn edit_bind(command: EditCommand) -> ReedlineEvent {
+    ReedlineEvent::Edit(vec![command])
+}
+
 /// Returns the current default emacs keybindings
 pub fn default_emacs_keybindings() -> Keybindings {
-    use KeyCode::*;
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
-    let mut keybindings = Keybindings::new();
+    let mut kb = Keybindings::new();
 
     // CTRL
-    keybindings.add_binding(KeyModifiers::CONTROL, Char('g'), vec![EditCommand::Redo]);
-    keybindings.add_binding(KeyModifiers::CONTROL, Char('z'), vec![EditCommand::Undo]);
-    keybindings.add_binding(KeyModifiers::CONTROL, Char('d'), vec![EditCommand::Delete]);
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('a'),
-        vec![EditCommand::MoveToStart],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('e'),
-        vec![EditCommand::MoveToEnd],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('k'),
-        vec![EditCommand::CutToEnd],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('u'),
-        vec![EditCommand::CutFromStart],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('y'),
-        vec![EditCommand::PasteCutBuffer],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('b'),
-        vec![EditCommand::MoveLeft],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('f'),
-        vec![EditCommand::MoveRight],
-    );
-    keybindings.add_binding(KeyModifiers::CONTROL, Char('c'), vec![EditCommand::Clear]);
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('h'),
-        vec![EditCommand::Backspace],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('w'),
-        vec![EditCommand::CutWordLeft],
-    );
-    keybindings.add_binding(KeyModifiers::CONTROL, Left, vec![EditCommand::MoveWordLeft]);
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Right,
-        vec![EditCommand::MoveWordRight],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('p'),
-        vec![EditCommand::PreviousHistory],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('n'),
-        vec![EditCommand::NextHistory],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('r'),
-        vec![EditCommand::SearchHistory],
-    );
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Char('t'),
-        vec![EditCommand::SwapGraphemes],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Enter,
-        vec![EditCommand::InsertChar('\n')],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('b'),
-        vec![EditCommand::MoveWordLeft],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('f'),
-        vec![EditCommand::MoveWordRight],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('d'),
-        vec![EditCommand::CutWordRight],
-    );
-    keybindings.add_binding(KeyModifiers::ALT, Left, vec![EditCommand::MoveWordLeft]);
-    keybindings.add_binding(KeyModifiers::ALT, Right, vec![EditCommand::MoveWordRight]);
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Backspace,
-        vec![EditCommand::BackspaceWord],
-    );
-    keybindings.add_binding(KeyModifiers::ALT, Delete, vec![EditCommand::DeleteWord]);
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        Backspace,
-        vec![EditCommand::BackspaceWord],
-    );
-    keybindings.add_binding(KeyModifiers::CONTROL, Delete, vec![EditCommand::DeleteWord]);
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('u'),
-        vec![EditCommand::UppercaseWord],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('l'),
-        vec![EditCommand::LowercaseWord],
-    );
-    keybindings.add_binding(
-        KeyModifiers::ALT,
-        Char('c'),
-        vec![EditCommand::CapitalizeChar],
-    );
-    keybindings.add_binding(KeyModifiers::NONE, Backspace, vec![EditCommand::Backspace]);
-    keybindings.add_binding(KeyModifiers::NONE, Delete, vec![EditCommand::Delete]);
-    keybindings.add_binding(KeyModifiers::NONE, Home, vec![EditCommand::MoveToStart]);
-    keybindings.add_binding(KeyModifiers::NONE, End, vec![EditCommand::MoveToEnd]);
-    keybindings.add_binding(KeyModifiers::NONE, Up, vec![EditCommand::Up]);
-    keybindings.add_binding(KeyModifiers::NONE, Down, vec![EditCommand::Down]);
-    keybindings.add_binding(KeyModifiers::NONE, Left, vec![EditCommand::MoveLeft]);
-    keybindings.add_binding(KeyModifiers::NONE, Right, vec![EditCommand::MoveRight]);
+    kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(KM::CONTROL, KC::Right, edit_bind(EC::MoveWordRight));
+    kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
+    kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
+    kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
+    kb.add_binding(KM::CONTROL, KC::Char('d'), edit_bind(EC::Delete));
+    kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToStart));
+    kb.add_binding(KM::CONTROL, KC::Char('e'), edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
+    kb.add_binding(KM::CONTROL, KC::Char('y'), edit_bind(EC::PasteCutBuffer));
+    kb.add_binding(KM::CONTROL, KC::Char('b'), edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::CONTROL, KC::Char('f'), edit_bind(EC::MoveRight));
+    kb.add_binding(KM::CONTROL, KC::Char('c'), edit_bind(EC::Clear));
+    kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
+    kb.add_binding(KM::CONTROL, KC::Char('p'), edit_bind(EC::PreviousHistory));
+    kb.add_binding(KM::CONTROL, KC::Char('n'), edit_bind(EC::NextHistory));
+    kb.add_binding(KM::CONTROL, KC::Char('r'), edit_bind(EC::SearchHistory));
+    kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
+    kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
+    kb.add_binding(KM::ALT, KC::Char('f'), edit_bind(EC::MoveWordRight));
+    kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
+    kb.add_binding(KM::ALT, KC::Char('u'), edit_bind(EC::UppercaseWord));
+    kb.add_binding(KM::ALT, KC::Char('l'), edit_bind(EC::LowercaseWord));
+    kb.add_binding(KM::ALT, KC::Char('c'), edit_bind(EC::CapitalizeChar));
+    kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(KM::ALT, KC::Right, edit_bind(EC::MoveWordRight));
+    kb.add_binding(KM::ALT, KC::Enter, edit_bind(EC::InsertChar('\n')));
+    kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
+    kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::NONE, KC::Up, edit_bind(EC::Up));
+    kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToStart));
+    kb.add_binding(KM::NONE, KC::Down, edit_bind(EC::Down));
+    kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
+    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
 
-    keybindings
+    kb
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -98,10 +98,10 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::ALT, KC::Enter, edit_bind(EC::InsertChar('\n')));
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
-    kb.add_binding(KM::NONE, KC::Up, edit_bind(EC::Up));
+    kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToEnd));
     kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToStart));
-    kb.add_binding(KM::NONE, KC::Down, edit_bind(EC::Down));
+    kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
     kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
     kb.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -85,7 +85,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
     kb.add_binding(KM::CONTROL, KC::Char('p'), ReedlineEvent::PreviousHistory);
     kb.add_binding(KM::CONTROL, KC::Char('n'), ReedlineEvent::NextHistory);
-    kb.add_binding(KM::CONTROL, KC::Char('r'), edit_bind(EC::SearchHistory));
+    kb.add_binding(KM::CONTROL, KC::Char('r'), ReedlineEvent::SearchHistory);
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
     kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
     kb.add_binding(KM::ALT, KC::Char('f'), edit_bind(EC::MoveWordRight));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -83,8 +83,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('c'), edit_bind(EC::Clear));
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
-    kb.add_binding(KM::CONTROL, KC::Char('p'), edit_bind(EC::PreviousHistory));
-    kb.add_binding(KM::CONTROL, KC::Char('n'), edit_bind(EC::NextHistory));
+    kb.add_binding(KM::CONTROL, KC::Char('p'), ReedlineEvent::PreviousHistory);
+    kb.add_binding(KM::CONTROL, KC::Char('n'), ReedlineEvent::NextHistory);
     kb.add_binding(KM::CONTROL, KC::Char('r'), edit_bind(EC::SearchHistory));
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
     kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -92,10 +92,14 @@ impl Vi {
                     output.push(EditCommand::MoveRight);
                 }
                 'j' => {
-                    output.push(EditCommand::PreviousHistory);
+                    // j in normal mode is not an editor command but it prompts us to execute the
+                    // down routine
+                    return ReedlineEvent::NextHistory;
                 }
                 'k' => {
-                    output.push(EditCommand::NextHistory);
+                    // k in normal mode is not an editor command but it prompts us to execute the
+                    // up routine
+                    return ReedlineEvent::PreviousHistory;
                 }
                 'i' => {
                     // NOTE: Ability to handle this with multiple events

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -94,12 +94,12 @@ impl Vi {
                 'j' => {
                     // j in normal mode is not an editor command but it prompts us to execute the
                     // down routine
-                    return ReedlineEvent::NextHistory;
+                    return ReedlineEvent::Down;
                 }
                 'k' => {
                     // k in normal mode is not an editor command but it prompts us to execute the
                     // up routine
-                    return ReedlineEvent::PreviousHistory;
+                    return ReedlineEvent::Up;
                 }
                 'i' => {
                     // NOTE: Ability to handle this with multiple events

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -53,7 +53,7 @@ impl EditMode for Vi {
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => {
                     if let Some(binding) = self.keybindings.find_binding(modifiers, code) {
-                        ReedlineEvent::Edit(binding)
+                        binding
                     } else {
                         ReedlineEvent::Edit(vec![])
                     }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -47,7 +47,7 @@ impl EditMode for Vi {
                     if self.mode == Mode::Normal {
                         self.parse_vi_fragment(c)
                     } else {
-                        ReedlineEvent::EditInsert(EditCommand::InsertChar(c))
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
                     }
                 }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -331,9 +331,6 @@ impl Reedline {
                         self.history.back()
                     }
                 }
-                EditCommand::SearchHistory => {
-                    self.history.back();
-                }
                 _ => {
                     self.input_mode = InputMode::Regular;
                 }
@@ -433,7 +430,6 @@ impl Reedline {
                 EditCommand::BackspaceWord => self.editor.backspace_word(),
                 EditCommand::DeleteWord => self.editor.delete_word(),
                 EditCommand::Clear => self.editor.clear(),
-                EditCommand::SearchHistory => self.search_history(),
                 EditCommand::CutFromStart => self.editor.cut_from_start(),
                 EditCommand::CutToEnd => self.editor.cut_from_end(),
                 EditCommand::CutWordLeft => self.editor.cut_word_left(),
@@ -827,6 +823,15 @@ impl Reedline {
                     self.down_command();
                 }
                 self.buffer_paint(self.prompt_widget.offset)?;
+                Ok(None)
+            }
+            ReedlineEvent::SearchHistory => {
+                if self.input_mode == InputMode::HistorySearch {
+                    self.history.back();
+                } else {
+                    self.search_history();
+                }
+                self.repaint(prompt)?;
                 Ok(None)
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -462,7 +462,6 @@ impl Reedline {
                 EditCommand::SwapGraphemes => self.editor.swap_graphemes(),
                 EditCommand::Undo => self.editor.undo(),
                 EditCommand::Redo => self.editor.redo(),
-                _ => {}
             }
 
             if [

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -331,10 +331,10 @@ impl Reedline {
                         self.history.back()
                     }
                 }
-                EditCommand::SearchHistory | EditCommand::Up | EditCommand::PreviousHistory => {
+                EditCommand::SearchHistory | EditCommand::Up => {
                     self.history.back();
                 }
-                EditCommand::Down | EditCommand::NextHistory => {
+                EditCommand::Down => {
                     self.history.forward();
                     // Hacky way to ensure that we don't fall of into failed search going forward
                     if self.history.string_at_cursor().is_none() {
@@ -416,10 +416,7 @@ impl Reedline {
         if self.input_mode == InputMode::HistoryTraversal {
             for command in commands {
                 match command {
-                    EditCommand::Up
-                    | EditCommand::Down
-                    | EditCommand::NextHistory
-                    | EditCommand::PreviousHistory => {}
+                    EditCommand::Up | EditCommand::Down => {}
                     _ => {
                         if matches!(
                             self.history.get_navigation(),
@@ -450,8 +447,6 @@ impl Reedline {
                 EditCommand::BackspaceWord => self.editor.backspace_word(),
                 EditCommand::DeleteWord => self.editor.delete_word(),
                 EditCommand::Clear => self.editor.clear(),
-                EditCommand::PreviousHistory => self.previous_history(),
-                EditCommand::NextHistory => self.next_history(),
                 EditCommand::Up => self.up_command(),
                 EditCommand::Down => self.down_command(),
                 EditCommand::SearchHistory => self.search_history(),
@@ -805,6 +800,28 @@ impl Reedline {
                 if self.input_mode != InputMode::HistorySearch {
                     self.full_repaint(prompt, self.prompt_widget.origin)?;
                 }
+                Ok(None)
+            }
+            ReedlineEvent::PreviousHistory => {
+                if self.input_mode == InputMode::HistorySearch {
+                    self.history.back();
+                } else {
+                    self.previous_history();
+                }
+                self.buffer_paint(self.prompt_widget.offset)?;
+                Ok(None)
+            }
+            ReedlineEvent::NextHistory => {
+                if self.input_mode == InputMode::HistorySearch {
+                    self.history.forward();
+                    // Hacky way to ensure that we don't fall of into failed search going forward
+                    if self.history.string_at_cursor().is_none() {
+                        self.history.back();
+                    }
+                } else {
+                    self.next_history();
+                }
+                self.buffer_paint(self.prompt_widget.offset)?;
                 Ok(None)
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -456,7 +456,6 @@ impl Reedline {
                 EditCommand::BackspaceWord => self.editor.backspace_word(),
                 EditCommand::DeleteWord => self.editor.delete_word(),
                 EditCommand::Clear => self.editor.clear(),
-                EditCommand::AppendToHistory => self.append_to_history(),
                 EditCommand::PreviousHistory => self.previous_history(),
                 EditCommand::NextHistory => self.next_history(),
                 EditCommand::Up => self.up_command(),
@@ -725,7 +724,8 @@ impl Reedline {
                 InputMode::Regular | InputMode::HistoryTraversal => {
                     let buffer = self.insertion_line().to_string();
 
-                    self.run_edit_commands(&[EditCommand::AppendToHistory, EditCommand::Clear]);
+                    self.append_to_history();
+                    self.run_edit_commands(&[EditCommand::Clear]);
                     self.print_crlf()?;
                     self.editor.reset_olds();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -714,18 +714,8 @@ impl Reedline {
                 self.editor.reset_olds();
                 Ok(Some(Signal::CtrlL))
             }
-            ReedlineEvent::Enter => match self.input_mode {
-                InputMode::Regular | InputMode::HistoryTraversal => {
-                    let buffer = self.insertion_line().to_string();
-
-                    self.append_to_history();
-                    self.run_edit_commands(&[EditCommand::Clear]);
-                    self.print_crlf()?;
-                    self.editor.reset_olds();
-
-                    Ok(Some(Signal::Success(buffer)))
-                }
-                InputMode::HistorySearch => {
+            ReedlineEvent::Enter => {
+                if self.input_mode == InputMode::HistorySearch {
                     self.queue_prompt_indicator(prompt)?;
 
                     if let Some(string) = self.history.string_at_cursor() {
@@ -735,8 +725,17 @@ impl Reedline {
                     self.input_mode = InputMode::Regular;
                     self.repaint(prompt)?;
                     Ok(None)
+                } else {
+                    let buffer = self.insertion_line().to_string();
+
+                    self.append_to_history();
+                    self.run_edit_commands(&[EditCommand::Clear]);
+                    self.print_crlf()?;
+                    self.editor.reset_olds();
+
+                    Ok(Some(Signal::Success(buffer)))
                 }
-            },
+            }
             ReedlineEvent::EditInsert(EditCommand::InsertChar(c)) => {
                 if self.input_mode == InputMode::HistorySearch {
                     let commnds = vec![EditCommand::InsertChar(c)];

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -359,7 +359,7 @@ impl Reedline {
     }
 
     fn append_to_history(&mut self) {
-        self.history.append(self.insertion_line().to_string());
+        self.history.append(self.editor.get_buffer().to_string());
     }
 
     fn previous_history(&mut self) {
@@ -389,7 +389,7 @@ impl Reedline {
                 self.editor.line_buffer().clone(),
             ));
         } else {
-            let buffer = self.insertion_line().to_string();
+            let buffer = self.editor.get_buffer().to_string();
             self.history
                 .set_navigation(HistoryNavigationQuery::PrefixSearch(buffer));
         }
@@ -409,7 +409,7 @@ impl Reedline {
                 HistoryNavigationQuery::Normal(_)
             ) {
                 if let Some(string) = self.history.string_at_cursor() {
-                    self.set_buffer(string)
+                    self.editor.set_buffer(string)
                 }
             }
             self.input_mode = InputMode::Regular;
@@ -472,23 +472,13 @@ impl Reedline {
         self.editor.set_insertion_point(self.editor.line(), pos)
     }
 
-    /// Get the current line of a multi-line edit [`LineBuffer`]
-    fn insertion_line(&self) -> &str {
-        self.editor.get_buffer()
-    }
-
-    /// Reset the [`LineBuffer`] to be a line specified by `buffer`
-    fn set_buffer(&mut self, buffer: String) {
-        self.editor.set_buffer(buffer)
-    }
-
     /// Heuristic to predetermine if we need to poll the terminal if the text wrapped around.
     fn might_require_wrapping(&self, start_offset: u16, c: char) -> bool {
         use unicode_width::UnicodeWidthStr;
 
         let terminal_width = self.terminal_columns();
 
-        let mut test_buffer = self.insertion_line().to_string();
+        let mut test_buffer = self.editor.get_buffer().to_string();
         test_buffer.push(c);
 
         let display_width = UnicodeWidthStr::width(test_buffer.as_str()) + start_offset as usize;
@@ -521,7 +511,7 @@ impl Reedline {
     /// Requires coordinates where the input buffer begins after the prompt.
     fn buffer_paint(&mut self, prompt_offset: (u16, u16)) -> Result<()> {
         let cursor_position_in_buffer = self.editor.offset();
-        let buffer_to_paint = self.insertion_line().to_string();
+        let buffer_to_paint = self.editor.get_buffer().to_string();
         let highlighted_line = self
             .highlighter
             .highlight(&buffer_to_paint)
@@ -545,7 +535,7 @@ impl Reedline {
         prompt_origin: (u16, u16),
     ) -> Result<(u16, u16)> {
         let prompt_mode = self.prompt_edit_mode();
-        let buffer_to_paint = self.insertion_line().to_string();
+        let buffer_to_paint = self.editor.get_buffer().to_string();
 
         let cursor_position_in_buffer = self.editor.offset();
         let highlighted_line = self
@@ -692,7 +682,7 @@ impl Reedline {
                 self.queue_prompt_indicator(prompt)?;
 
                 if let Some(string) = self.history.string_at_cursor() {
-                    self.set_buffer(string)
+                    self.editor.set_buffer(string)
                 }
 
                 self.input_mode = InputMode::Regular;
@@ -799,7 +789,7 @@ impl Reedline {
                 Ok(Some(Signal::CtrlL))
             }
             ReedlineEvent::Enter => {
-                let buffer = self.insertion_line().to_string();
+                let buffer = self.editor.get_buffer().to_string();
 
                 self.append_to_history();
                 self.run_edit_commands(&[EditCommand::Clear]);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -108,16 +108,36 @@ pub enum EditCommand {
     Redo,
 }
 
+/// Reedline supported actions.
 #[derive(Serialize, Deserialize, Clone)]
 pub enum ReedlineEvent {
+    /// Trigger Tab
     HandleTab,
-    CtrlD, // Don't know a better name for this
-    CtrlC, // Don't know a better name for this
+
+    /// Don't know a better name for this
+    CtrlD,
+
+    /// Don't know a better name for this
+    CtrlC,
+
+    /// Clears the screen and sets prompt to first line
     ClearScreen,
+
+    /// Handle enter event
     Enter,
+
+    /// Mouse
     Mouse, // Fill in details later
+
+    /// trigger termimal resize
     Resize(u16, u16),
-    EditInsert(EditCommand), // HACK: Special handling for insert
+
+    /// HACK: Special handling for insert
+    EditInsert(EditCommand),
+
+    /// Run these commands in the editor
     Edit(Vec<EditCommand>),
+
+    /// Trigger full repaint
     Repaint,
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -56,9 +56,6 @@ pub enum EditCommand {
     /// Delete in-place a word from the current insertion point
     DeleteWord,
 
-    /// Add a buffer to the historic buffers
-    AppendToHistory,
-
     /// Navigate to the previous historic buffer
     PreviousHistory,
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -108,6 +108,7 @@ pub enum EditCommand {
     Redo,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
 pub enum ReedlineEvent {
     HandleTab,
     CtrlD, // Don't know a better name for this

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -35,12 +35,6 @@ pub enum EditCommand {
     /// Move one word to the right
     MoveWordRight,
 
-    /// Move up to the previous line, if multiline, or up into the historic buffers
-    Up,
-
-    /// Move down to the next line, if multiline, or down through the historic buffers
-    Down,
-
     /// Insert a character at the current insertion point
     InsertChar(char),
 
@@ -134,6 +128,12 @@ pub enum ReedlineEvent {
 
     /// Navigate to the previous historic buffer
     PreviousHistory,
+
+    /// Move up to the previous line, if multiline, or up into the historic buffers
+    Up,
+
+    /// Move down to the next line, if multiline, or down through the historic buffers
+    Down,
 
     /// Navigate to the next historic buffer
     NextHistory,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -92,9 +92,6 @@ pub enum EditCommand {
     /// Swap the current grapheme/character with the one to the right
     SwapGraphemes,
 
-    /// Send a code fragment to the vi handler
-    ViCommandFragment(char),
-
     /// Undo the previous edit command
     Undo,
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -56,12 +56,6 @@ pub enum EditCommand {
     /// Delete in-place a word from the current insertion point
     DeleteWord,
 
-    /// Navigate to the previous historic buffer
-    PreviousHistory,
-
-    /// Navigate to the next historic buffer
-    NextHistory,
-
     /// Search the history for a string
     SearchHistory,
 
@@ -140,4 +134,10 @@ pub enum ReedlineEvent {
 
     /// Trigger full repaint
     Repaint,
+
+    /// Navigate to the previous historic buffer
+    PreviousHistory,
+
+    /// Navigate to the next historic buffer
+    NextHistory,
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -50,9 +50,6 @@ pub enum EditCommand {
     /// Delete in-place a word from the current insertion point
     DeleteWord,
 
-    /// Search the history for a string
-    SearchHistory,
-
     /// Clear the current buffer
     Clear,
 
@@ -137,4 +134,7 @@ pub enum ReedlineEvent {
 
     /// Navigate to the next historic buffer
     NextHistory,
+
+    /// Search the history for a string
+    SearchHistory,
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -114,9 +114,6 @@ pub enum ReedlineEvent {
     /// trigger termimal resize
     Resize(u16, u16),
 
-    /// HACK: Special handling for insert
-    EditInsert(EditCommand),
-
     /// Run these commands in the editor
     Edit(Vec<EditCommand>),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,14 @@
 //! use std::io;
 //! use {
 //!   crossterm::event::{KeyCode, KeyModifiers},
-//!   reedline::{default_emacs_keybindings, EditCommand, Reedline, Emacs},
+//!   reedline::{default_emacs_keybindings, EditCommand, Reedline, Emacs, ReedlineEvent},
 //! };
 //!
 //! let mut keybindings = default_emacs_keybindings();
 //! keybindings.add_binding(
 //!     KeyModifiers::ALT,
 //!     KeyCode::Char('m'),
-//!     vec![EditCommand::BackspaceWord],
+//!     ReedlineEvent::Edit(vec![EditCommand::BackspaceWord]),
 //! );
 //! let edit_mode = Box::new(Emacs::new(keybindings));
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ mod core_editor;
 mod text_manipulation;
 
 mod enums;
-pub use enums::{EditCommand, Signal};
+pub use enums::{EditCommand, ReedlineEvent, Signal};
 
 mod painter;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use {
     reedline::{
         default_emacs_keybindings, DefaultCompleter, DefaultCompletionActionHandler,
         DefaultHighlighter, DefaultHinter, DefaultPrompt, EditCommand, FileBackedHistory, Reedline,
-        Signal,
+        ReedlineEvent, Signal,
     },
     std::{
         io::{stdout, Write},
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         keybindings.add_binding(
             KeyModifiers::ALT,
             KeyCode::Char('m'),
-            vec![EditCommand::BackspaceWord],
+            ReedlineEvent::Edit(vec![EditCommand::BackspaceWord]),
         );
         Box::new(Emacs::new(keybindings))
     };


### PR DESCRIPTION

I have done some refactors along the way. Let me know your thoughts on this.

This could have been 4-5 separate PRs, getting them reviewed/merged individually would have taken some time, so I just clubbed them together to save some time. (The squashing merge of PRs also makes it hard to rebase, otherwise, that could have saved a lot of trouble and I would have managed to do multiple PRs - This might just be a lack of knowledge on my side, if there is an easy way to rebase with the squashed stuff please do tell me.). 

Meanwhile here are all the things that this PR tries to do

## Extraction of `Hinter` and `Highlighter` out of `Painter`

`Hinter` has logic that is more than just display specific so it does not make sense for it to be a part of `Painter` (A component that is supposed to only care about screen painting operations). Though the same can not be said about the `Highlighter`. The `Highlighter` does deal with display elements, though currently, it understands what a `LineBuffer` is, which makes me skeptical about its presence in `Painter`.
Maybe we can have an interface with `Painter` where we supply 3-tuple (kinda) object `(before_cursor_string, virtual_text/hint, after_cursor_string)`, then the `Highlighter` can do anything with this info whilst residing inside the `Painter`.

## Change `Keybinding` structure to use use  `ReedlineEvent` instead of `Vec<EditCommand>` 

Given that the `Keybinding` operates on more than the editor stuff (e.g. history, etc)  it should follow that its internal structure reflects this.  `ReedlineEvent` (in need of a better name) is the `enum` that fits this bill IMO.

## Pull non-editor commands out of EditCommand to ReedlineEvent

As mentioned in https://github.com/jntrnr/reedline/pull/134#issuecomment-904327380  the following 
```rust
EditCommand::Clear
EditCommand::Up
EditCommand::Down
EditCommand::AppendToHistory
EditCommand::PreviousHistory
EditCommand::NextHistory
EditCommand::SearchHistory
```
make more sense in `ReedlineEvent` than they do in `EditCommand`, for the reason that these aren't really editor operations which `EditCommand` should be interested in.

## Pull history search-related specific decisions to the top level.

History search operations are too deep down in the code which makes it a high coupling piece. I wanted to try and reduce that coupling and as a result, I have pulled this up.
Another way to think about this is that when we start history search by pressing Ctrl-R (or equivalent) we essentially start another editor with limited functionality and the result from this is carried over to any line-editors buffer. (Kinda like how shell and line-editor interact)
Maybe eventually we can have a shared editor between struct (different instances) thus providing best in class history search experience with minimal effort from our side. Thoughts?
But currently, The distinction is made between how the handling of events happens at the top level (instead of the old way where it was taking place nestled down deep)

## Resolve `InsertChar` hack in `ReedlineEvent`

Initially, I added a hack (special brach in `ReedlineEvent` enum to handle `InsertChar`) to simplify pulling handle-event into a separate function. So this just fixes that hack. 

