### PR TITLE
Add tests to emacs and vi edit mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "crossterm",
  "nu-ansi-term",
  "pretty_assertions",
+ "rstest",
  "serde",
  "tempfile",
  "unicode-segmentation",
@@ -421,10 +422,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ unicode-width = "0.1.8"
 [dev-dependencies]
 tempfile = "3.2.0"
 pretty_assertions = "0.7.2"
+rstest = "0.11.0"
 
 [features]
 system_clipboard = ["clipboard"]

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -138,4 +138,20 @@ mod test {
         // Right now this returns ReedlineEvent::Edit(vec![]), but what should we really return
         assert_eq!(result, ReedlineEvent::HandleTab);
     }
+
+    #[test]
+    fn inserting_capital_character_for_non_ascii_remains_as_is() {
+        let mut emacs = Emacs::default();
+
+        let uppercase_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::SHIFT,
+            code: KeyCode::Char('😀'),
+        });
+        let result = emacs.parse_event(uppercase_l);
+
+        assert_eq!(
+            result,
+            ReedlineEvent::Edit(vec![EditCommand::InsertChar('😀')])
+        );
+    }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -35,7 +35,7 @@ impl EditMode for Emacs {
                 _ => self
                     .keybindings
                     .find_binding(modifiers, code)
-                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
+                    .unwrap_or(ReedlineEvent::None),
             },
 
             Event::Mouse(_) => ReedlineEvent::Mouse,
@@ -123,9 +123,8 @@ mod test {
         );
     }
 
-    #[ignore = "Unsure what the desired behaviour is"]
     #[test]
-    fn return_IDONT_KNOW_WHAT_when_keybinding_is_not_found() {
+    fn return_none_reedline_event_when_keybinding_is_not_found() {
         let keybindings = Keybindings::default();
 
         let mut emacs = Emacs::new(keybindings);
@@ -135,8 +134,7 @@ mod test {
         });
         let result = emacs.parse_event(ctrl_l);
 
-        // Right now this returns ReedlineEvent::Edit(vec![]), but what should we really return
-        assert_eq!(result, ReedlineEvent::HandleTab);
+        assert_eq!(result, ReedlineEvent::None);
     }
 
     #[test]

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -72,7 +72,6 @@ mod test {
         assert_eq!(result, ReedlineEvent::ClearScreen);
     }
 
-    #[ignore = "Unsure what the desired behaviour is"]
     #[test]
     fn overriding_default_keybindings_works() {
         let mut keybindings = default_emacs_keybindings();

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -25,8 +25,11 @@ impl EditMode for Emacs {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (m, KeyCode::Char(c)) if m == KeyModifiers::NONE | KeyModifiers::SHIFT => {
+                (KeyModifiers::NONE, KeyCode::Char(c)) => {
                     ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                }
+                (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c.to_ascii_uppercase())])
                 }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => self
@@ -87,5 +90,36 @@ mod test {
         let result = emacs.parse_event(ctrl_l);
 
         assert_eq!(result, ReedlineEvent::HandleTab);
+    }
+
+    #[test]
+    fn inserting_character_works() {
+        let mut emacs = Emacs::default();
+        let l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::NONE,
+            code: KeyCode::Char('l'),
+        });
+        let result = emacs.parse_event(l);
+
+        assert_eq!(
+            result,
+            ReedlineEvent::Edit(vec![EditCommand::InsertChar('l')])
+        );
+    }
+
+    #[test]
+    fn inserting_capital_character_works() {
+        let mut emacs = Emacs::default();
+
+        let uppercase_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::SHIFT,
+            code: KeyCode::Char('l'),
+        });
+        let result = emacs.parse_event(uppercase_l);
+
+        assert_eq!(
+            result,
+            ReedlineEvent::Edit(vec![EditCommand::InsertChar('L')])
+        );
     }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -122,4 +122,20 @@ mod test {
             ReedlineEvent::Edit(vec![EditCommand::InsertChar('L')])
         );
     }
+
+    #[ignore = "Unsure what the desired behaviour is"]
+    #[test]
+    fn return_IDONT_KNOW_WHAT_when_keybinding_is_not_found() {
+        let keybindings = Keybindings::default();
+
+        let mut emacs = Emacs::new(keybindings);
+        let ctrl_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('l'),
+        });
+        let result = emacs.parse_event(ctrl_l);
+
+        // Right now this returns ReedlineEvent::Edit(vec![]), but what should we really return
+        assert_eq!(result, ReedlineEvent::HandleTab);
+    }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -25,7 +25,9 @@ impl EditMode for Emacs {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (_, KeyCode::Char(c)) => ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)]),
+                (m, KeyCode::Char(c)) if m == KeyModifiers::NONE | KeyModifiers::SHIFT => {
+                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => self
                     .keybindings

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -25,12 +25,7 @@ impl EditMode for Emacs {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (KeyModifiers::NONE, KeyCode::Tab) => ReedlineEvent::HandleTab,
-                (KeyModifiers::CONTROL, KeyCode::Char('d')) => ReedlineEvent::CtrlD,
-                (KeyModifiers::CONTROL, KeyCode::Char('c')) => ReedlineEvent::CtrlC,
-                (KeyModifiers::CONTROL, KeyCode::Char('l')) => ReedlineEvent::ClearScreen,
-                (KeyModifiers::NONE, KeyCode::Char(c))
-                | (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                (m, KeyCode::Char(c)) if m == KeyModifiers::SHIFT | KeyModifiers::NONE => {
                     ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
                 }
                 (m, KeyCode::Char(c)) if m == KeyModifiers::CONTROL | KeyModifiers::ALT => {

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -51,3 +51,41 @@ impl Emacs {
         Emacs { keybindings }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn ctrl_l_leads_to_clear_screen_event() {
+        let mut emacs = Emacs::default();
+        let ctrl_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('l'),
+        });
+        let result = emacs.parse_event(ctrl_l);
+
+        assert_eq!(result, ReedlineEvent::ClearScreen);
+    }
+
+    #[ignore = "Unsure what the desired behaviour is"]
+    #[test]
+    fn overriding_default_keybindings_works() {
+        let mut keybindings = default_emacs_keybindings();
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('l'),
+            ReedlineEvent::HandleTab,
+        );
+
+        let mut emacs = Emacs::new(keybindings);
+        let ctrl_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('l'),
+        });
+        let result = emacs.parse_event(ctrl_l);
+
+        assert_eq!(result, ReedlineEvent::HandleTab);
+    }
+}

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -25,20 +25,12 @@ impl EditMode for Emacs {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (m, KeyCode::Char(c)) if m == KeyModifiers::SHIFT | KeyModifiers::NONE => {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                }
-                (m, KeyCode::Char(c)) if m == KeyModifiers::CONTROL | KeyModifiers::ALT => {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                }
+                (_, KeyCode::Char(c)) => ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)]),
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
-                _ => {
-                    if let Some(binding) = self.keybindings.find_binding(modifiers, code) {
-                        binding
-                    } else {
-                        ReedlineEvent::Edit(vec![])
-                    }
-                }
+                _ => self
+                    .keybindings
+                    .find_binding(modifiers, code)
+                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
             },
 
             Event::Mouse(_) => ReedlineEvent::Mouse,

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -117,3 +117,24 @@ pub fn default_emacs_keybindings() -> Keybindings {
 
     kb
 }
+
+pub fn default_vi_normal_keybindings() -> Keybindings {
+    Keybindings::new()
+}
+
+pub fn default_vi_insert_keybindings() -> Keybindings {
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
+
+    let mut keybindings = Keybindings::new();
+
+    keybindings.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
+    keybindings.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
+    keybindings.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
+    keybindings.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
+    keybindings.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
+    keybindings.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+
+    keybindings
+}

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::enums::ReedlineEvent;
 
 use {
@@ -6,16 +8,15 @@ use {
     serde::{Deserialize, Serialize},
 };
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Keybinding {
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct KeyCombination {
     modifier: KeyModifiers,
     key_code: KeyCode,
-    command: ReedlineEvent,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Keybindings {
-    pub bindings: Vec<Keybinding>,
+    pub bindings: HashMap<KeyCombination, ReedlineEvent>,
 }
 
 impl Default for Keybindings {
@@ -26,7 +27,9 @@ impl Default for Keybindings {
 
 impl Keybindings {
     pub fn new() -> Self {
-        Self { bindings: vec![] }
+        Self {
+            bindings: HashMap::new(),
+        }
     }
 
     pub fn empty() -> Self {
@@ -39,21 +42,13 @@ impl Keybindings {
         key_code: KeyCode,
         command: ReedlineEvent,
     ) {
-        self.bindings.push(Keybinding {
-            modifier,
-            key_code,
-            command,
-        });
+        let key_combo = KeyCombination { modifier, key_code };
+        self.bindings.insert(key_combo, command);
     }
 
     pub fn find_binding(&self, modifier: KeyModifiers, key_code: KeyCode) -> Option<ReedlineEvent> {
-        for binding in &self.bindings {
-            if binding.modifier == modifier && binding.key_code == key_code {
-                return Some(binding.command.clone());
-            }
-        }
-
-        None
+        let key_combo = KeyCombination { modifier, key_code };
+        self.bindings.get(&key_combo).cloned()
     }
 }
 

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -70,6 +70,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Right, edit_bind(EC::MoveWordRight));
     kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::CONTROL, KC::Char('d'), ReedlineEvent::CtrlD);
+    kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
     kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
     kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
     kb.add_binding(KM::CONTROL, KC::Char('d'), edit_bind(EC::Delete));
@@ -87,6 +89,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('n'), ReedlineEvent::NextHistory);
     kb.add_binding(KM::CONTROL, KC::Char('r'), ReedlineEvent::SearchHistory);
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
+    kb.add_binding(KM::CONTROL, KC::Char('l'), ReedlineEvent::ClearScreen);
     kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
     kb.add_binding(KM::ALT, KC::Char('f'), edit_bind(EC::MoveWordRight));
     kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
@@ -100,6 +103,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::HandleTab);
     kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToStart));
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
     kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -29,6 +29,10 @@ impl Keybindings {
         Self { bindings: vec![] }
     }
 
+    pub fn empty() -> Self {
+        Self::new()
+    }
+
     pub fn add_binding(
         &mut self,
         modifier: KeyModifiers,

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -57,11 +57,11 @@ impl EditMode for Vi {
                 (Mode::Normal, _, _) => self
                     .normal_keybindings
                     .find_binding(modifiers, code)
-                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
+                    .unwrap_or(ReedlineEvent::None),
                 (Mode::Insert, _, _) => self
                     .insert_keybindings
                     .find_binding(modifiers, code)
-                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
+                    .unwrap_or(ReedlineEvent::None),
             },
 
             Event::Mouse(_) => ReedlineEvent::Mouse,
@@ -229,5 +229,25 @@ mod test {
 
         assert_eq!(result, ReedlineEvent::Repaint);
         assert_eq!(vi.mode, Mode::Normal);
+    }
+
+    #[rstest]
+    #[case(Mode::Normal)]
+    #[case(Mode::Insert)]
+    fn return_none_reedline_event_when_keybinding_is_not_found(#[case] mode: Mode) {
+        let mut vi = Vi {
+            insert_keybindings: Keybindings::empty(),
+            normal_keybindings: Keybindings::empty(),
+            partial: None,
+            mode,
+        };
+
+        let ctrl_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('l'),
+        });
+        let result = vi.parse_event(ctrl_l);
+
+        assert_eq!(result, ReedlineEvent::None);
     }
 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -230,21 +230,4 @@ mod test {
         assert_eq!(result, ReedlineEvent::Repaint);
         assert_eq!(vi.mode, Mode::Normal);
     }
-
-    #[test]
-    fn ctrl_l_leads_to_clear_screen_event_in_insert_mode() {
-        let mut vi = Vi {
-            insert_keybindings: default_vi_insert_mode_keybindings(),
-            normal_keybindings: Keybindings::empty(),
-            partial: None,
-            mode: Mode::Insert,
-        };
-        let ctrl_l = Event::Key(KeyEvent {
-            modifiers: KeyModifiers::CONTROL,
-            code: KeyCode::Char('l'),
-        });
-        let result = vi.parse_event(ctrl_l);
-
-        assert_eq!(result, ReedlineEvent::ClearScreen);
-    }
 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -1,12 +1,13 @@
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
+use super::EditMode;
 use crate::{
-    default_emacs_keybindings,
+    edit_mode::keybindings::{
+        default_vi_insert_keybindings, default_vi_normal_keybindings, Keybindings,
+    },
     enums::{EditCommand, ReedlineEvent},
     PromptEditMode, PromptViMode,
 };
-
-use super::{keybindings::Keybindings, EditMode};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum Mode {
@@ -22,19 +23,11 @@ pub struct Vi {
     mode: Mode,
 }
 
-fn default_vi_insert_mode_keybindings() -> Keybindings {
-    default_emacs_keybindings()
-}
-
-fn default_vi_normal_mode_keybindings() -> Keybindings {
-    Keybindings::new()
-}
-
 impl Default for Vi {
     fn default() -> Self {
         Vi {
-            insert_keybindings: default_vi_insert_mode_keybindings(),
-            normal_keybindings: default_vi_normal_mode_keybindings(),
+            insert_keybindings: default_vi_insert_keybindings(),
+            normal_keybindings: default_vi_normal_keybindings(),
             partial: None,
             mode: Mode::Normal,
         }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{keybindings::Keybindings, EditMode};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum Mode {
     Normal,
     Insert,
@@ -17,15 +17,24 @@ enum Mode {
 /// This parses incomming input `Event`s like a Vi-Style editor
 pub struct Vi {
     partial: Option<String>,
-    keybindings: Keybindings,
+    insert_keybindings: Keybindings,
+    normal_keybindings: Keybindings,
     mode: Mode,
+}
+
+fn default_vi_insert_mode_keybindings() -> Keybindings {
+    default_emacs_keybindings()
+}
+
+fn default_vi_normal_mode_keybindings() -> Keybindings {
+    Keybindings::new()
 }
 
 impl Default for Vi {
     fn default() -> Self {
         Vi {
-            // FIXME: Setup proper keybinds
-            keybindings: default_emacs_keybindings(),
+            insert_keybindings: default_vi_insert_mode_keybindings(),
+            normal_keybindings: default_vi_normal_mode_keybindings(),
             partial: None,
             mode: Mode::Normal,
         }
@@ -35,36 +44,31 @@ impl Default for Vi {
 impl EditMode for Vi {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
-            Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (KeyModifiers::NONE, KeyCode::Tab) => ReedlineEvent::HandleTab,
-                (KeyModifiers::CONTROL, KeyCode::Char('c')) => ReedlineEvent::CtrlC,
-                (KeyModifiers::NONE, KeyCode::Esc) => {
+            Event::Key(KeyEvent { code, modifiers }) => match (self.mode, modifiers, code) {
+                (_, KeyModifiers::NONE, KeyCode::Tab) => ReedlineEvent::HandleTab,
+                (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.mode = Mode::Normal;
                     ReedlineEvent::Repaint
                 }
-                (KeyModifiers::NONE, KeyCode::Char(c))
-                | (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
-                    if self.mode == Mode::Normal {
-                        self.parse_vi_fragment(c)
-                    } else {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                    }
+                (Mode::Normal, KeyModifiers::NONE, KeyCode::Char(c)) => self.parse_vi_fragment(c),
+                (Mode::Normal, KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                    self.parse_vi_fragment(c.to_ascii_uppercase())
                 }
-                (m, KeyCode::Char(c)) if m == KeyModifiers::CONTROL | KeyModifiers::ALT => {
-                    if self.mode == Mode::Normal {
-                        self.parse_vi_fragment(c)
-                    } else {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                    }
+                (Mode::Insert, KeyModifiers::NONE, KeyCode::Char(c)) => {
+                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
                 }
-                (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
-                _ => {
-                    if let Some(binding) = self.keybindings.find_binding(modifiers, code) {
-                        binding
-                    } else {
-                        ReedlineEvent::Edit(vec![])
-                    }
+                (Mode::Insert, KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c.to_ascii_uppercase())])
                 }
+                (_, KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
+                (Mode::Normal, _, _) => self
+                    .normal_keybindings
+                    .find_binding(modifiers, code)
+                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
+                (Mode::Insert, _, _) => self
+                    .insert_keybindings
+                    .find_binding(modifiers, code)
+                    .unwrap_or_else(|| ReedlineEvent::Edit(vec![])),
             },
 
             Event::Mouse(_) => ReedlineEvent::Mouse,
@@ -156,5 +160,98 @@ impl Vi {
         };
 
         ReedlineEvent::Edit(output)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    fn edit_event(cmd: EditCommand) -> ReedlineEvent {
+        ReedlineEvent::Edit(vec![cmd])
+    }
+
+    fn char_key_event(ch: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE))
+    }
+
+    #[rstest]
+    #[case('h', edit_event(EditCommand::MoveLeft))]
+    #[case('j', ReedlineEvent::Down)]
+    #[case('k', ReedlineEvent::Up)]
+    #[case('l', edit_event(EditCommand::MoveRight))]
+    #[case('u', edit_event(EditCommand::Undo))]
+    #[case('p', edit_event(EditCommand::PasteCutBuffer))]
+    #[case('w', edit_event(EditCommand::MoveWordRight))]
+    #[case('b', edit_event(EditCommand::MoveWordLeft))]
+    #[case('0', edit_event(EditCommand::MoveToStart))]
+    #[case('$', edit_event(EditCommand::MoveToEnd))]
+    #[case('A', edit_event(EditCommand::MoveToEnd))] // Not checking if it also moves to end
+    #[case('D', edit_event(EditCommand::CutToEnd))]
+    fn test_single_word_vi_commands(#[case] input: char, #[case] output: ReedlineEvent) {
+        let mut default_vi = Vi::default();
+
+        let event = char_key_event(input);
+        let result = default_vi.parse_event(event);
+
+        assert_eq!(result, output);
+    }
+
+    #[rstest]
+    #[case("dd", ReedlineEvent::Edit(vec![EditCommand::MoveToStart, EditCommand::CutToEnd]))]
+    #[case("dw", edit_event(EditCommand::CutWordRight))]
+    fn test_multiple_word_vi_commands(#[case] input: &str, #[case] output: ReedlineEvent) {
+        let mut default_vi = Vi::default();
+
+        let events = input.chars().map(char_key_event);
+
+        // Ideally this should be a fold but map works as vi has internal state
+        let result = events.map(|e| default_vi.parse_event(e)).last().unwrap();
+
+        assert_eq!(result, output);
+    }
+
+    #[test]
+    fn hitting_i_in_normal_mode_switches_the_mode() {
+        let mut default_vi = Vi::default();
+        let i = char_key_event('i');
+        let result = default_vi.parse_event(i);
+        assert_eq!(result, ReedlineEvent::Repaint);
+        assert_eq!(default_vi.mode, Mode::Insert);
+    }
+
+    #[test]
+    fn hitting_esc_in_insert_mode_switches_the_mode() {
+        let mut vi = Vi {
+            insert_keybindings: Keybindings::empty(),
+            normal_keybindings: Keybindings::empty(),
+            partial: None,
+            mode: Mode::Normal,
+        };
+
+        let esc = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let result = vi.parse_event(esc);
+
+        assert_eq!(result, ReedlineEvent::Repaint);
+        assert_eq!(vi.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn ctrl_l_leads_to_clear_screen_event_in_insert_mode() {
+        let mut vi = Vi {
+            insert_keybindings: default_vi_insert_mode_keybindings(),
+            normal_keybindings: Keybindings::empty(),
+            partial: None,
+            mode: Mode::Insert,
+        };
+        let ctrl_l = Event::Key(KeyEvent {
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('l'),
+        });
+        let result = vi.parse_event(ctrl_l);
+
+        assert_eq!(result, ReedlineEvent::ClearScreen);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -67,6 +67,7 @@ impl PromptWidget {
 ///    }
 ///    _ => {
 ///        eprintln!("Entry aborted!");
+///
 ///    }
 /// }
 /// # Ok::<(), io::Error>(())
@@ -489,6 +490,10 @@ impl Reedline {
                 self.repaint(prompt)?;
                 Ok(None)
             }
+            ReedlineEvent::None => {
+                // Default no operation
+                Ok(None)
+            }
         }
     }
 
@@ -581,6 +586,7 @@ impl Reedline {
                 self.repaint(prompt)?;
                 Ok(None)
             }
+            ReedlineEvent::None => Ok(None),
         }
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -16,7 +16,7 @@ pub enum Signal {
 /// Editing actions which can be mapped to key bindings.
 ///
 /// Executed by `Reedline::run_edit_commands()`
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum EditCommand {
     /// Move to the start of the buffer
     MoveToStart,
@@ -92,7 +92,7 @@ pub enum EditCommand {
 }
 
 /// Reedline supported actions.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum ReedlineEvent {
     /// Trigger Tab
     HandleTab,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -94,6 +94,9 @@ pub enum EditCommand {
 /// Reedline supported actions.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum ReedlineEvent {
+    /// No op event
+    None,
+
     /// Trigger Tab
     HandleTab,
 


### PR DESCRIPTION
This PR intends to add basic tests to the emacs edit mode.

There are two tests that are marked ignore, which I am unsure what they should be. Please add details on the desired behaviuor.

I personally think that 
- we should be able to override keybinds so it will require some work on the `KeyBinding` struct.
- I am not too sure what the default behaviour should be in-case of Events that don't have any definition. I was thinking of returning a default IGNORE event. Ideally, we should log the details along with doing nothing for that. Would like to know what others think about this.