### PR TITLE
Multiline improvements

### DIFF
--- a/src/completion/tab_handler.rs
+++ b/src/completion/tab_handler.rs
@@ -89,8 +89,8 @@ impl ComplationActionHandler for DefaultCompletionActionHandler {
                     offset += completions[index].1.len() - (span.end - span.start);
 
                     // TODO improve the support for multiline replace
-                    present_buffer.replace(span.start..span.end, 0, &completions[index].1);
-                    present_buffer.set_insertion_point(present_buffer.line(), offset);
+                    present_buffer.replace(span.start..span.end, &completions[index].1);
+                    present_buffer.set_insertion_point(offset);
                 }
                 _ => {
                     self.reset_index();
@@ -162,14 +162,14 @@ mod test {
         let mut buf = buffer_with("th is my test th");
 
         // Hitting tab after `th` fills the first completion `that`
-        buf.set_insertion_point(0, 2);
+        buf.set_insertion_point(2);
         tab.handle(&mut buf);
         let mut expected_buffer = buffer_with("that is my test th");
-        expected_buffer.set_insertion_point(0, 4);
+        expected_buffer.set_insertion_point(4);
         assert_eq!(buf, expected_buffer);
 
         // updating the cursor to end should reset the completions
-        buf.set_insertion_point(0, 18);
+        buf.set_insertion_point(18);
         tab.handle(&mut buf);
         assert_eq!(buf, buffer_with("that is my test that"));
     }

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -143,8 +143,16 @@ impl Editor {
         self.line_buffer.line()
     }
 
+    pub fn num_lines(&self) -> usize {
+        self.line_buffer.num_lines()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.line_buffer.is_empty()
+    }
+
+    pub fn ends_with(&self, c: char) -> bool {
+        self.line_buffer.ends_with(c)
     }
 
     pub fn is_cursor_at_first_line(&self) -> bool {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -108,8 +108,8 @@ impl Editor {
         self.line_buffer.swap_graphemes();
     }
 
-    pub fn set_insertion_point(&mut self, line: usize, pos: usize) {
-        self.line_buffer.set_insertion_point(line, pos)
+    pub fn set_insertion_point(&mut self, pos: usize) {
+        self.line_buffer.set_insertion_point(pos)
     }
 
     pub fn get_buffer(&self) -> &str {
@@ -239,8 +239,7 @@ impl Editor {
             self.cut_buffer
                 .set(&self.line_buffer.get_buffer()[cut_range.clone()]);
             self.clear_range(cut_range);
-            self.line_buffer
-                .set_insertion_point(self.line_buffer.line(), left_index);
+            self.line_buffer.set_insertion_point(left_index);
         }
     }
 

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -501,7 +501,7 @@ mod test {
 
         line_buffer.set_buffer("new line 1\nnew_line 2".to_string());
 
-        let after_operation_location = InsertionPoint { offset: 10 };
+        let after_operation_location = InsertionPoint { offset: 21 };
         assert_eq!(after_operation_location, line_buffer.insertion_point());
     }
 

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -391,7 +391,10 @@ impl LineBuffer {
         self.set_insertion_point(self.line(), position);
 
         // Move right from this position to the column we were at
-        while &buffer[position..(position + 1)] != "\n" && num_of_move_lefts > 0 {
+        while position < buffer.len()
+            && &buffer[position..(position + 1)] != "\n"
+            && num_of_move_lefts > 0
+        {
             self.move_right();
             position = self.offset();
             num_of_move_lefts -= 1;

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -72,6 +72,20 @@ impl LineBuffer {
         }
     }
 
+    pub fn num_lines(&self) -> usize {
+        let count = self.lines.split('\n').count();
+
+        if count == 0 {
+            1
+        } else {
+            count
+        }
+    }
+
+    pub fn ends_with(&self, c: char) -> bool {
+        self.lines.ends_with(c)
+    }
+
     /// Set to a single line of `buffer` and reset the `InsertionPoint` cursor
     pub fn set_buffer(&mut self, buffer: String) {
         let offset = buffer.len();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -559,6 +559,7 @@ impl Reedline {
                     Ok(Some(Signal::Success(buffer)))
                 } else {
                     self.run_edit_commands(&[EditCommand::InsertChar('\n')], prompt)?;
+
                     Ok(None)
                 }
             }
@@ -819,7 +820,7 @@ impl Reedline {
 
     /// Set the cursor position as understood by the underlying [`LineBuffer`] for the current line
     fn set_offset(&mut self, pos: usize) {
-        self.editor.set_insertion_point(self.editor.line(), pos)
+        self.editor.set_insertion_point(pos)
     }
 
     fn terminal_columns(&self) -> u16 {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -111,6 +111,15 @@ impl Painter {
         Ok(())
     }
 
+    /// Scroll by n rows
+    pub fn scroll_rows(&mut self, num_rows: u16) -> Result<()> {
+        self.stdout
+            .queue(crossterm::terminal::ScrollUp(num_rows))?
+            .flush()?;
+
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn repaint_everything(
         &mut self,


### PR DESCRIPTION
This makes working at the last line during a multiline a bit cleaner. Both up/down and new lines should now flow to the next line and properly scroll the input if you're at the bottom of the terminal.