### PR TITLE
Improve rendering of multiline

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -80,8 +80,8 @@ impl Painter {
     ) -> Result<()> {
         let (before_cursor, after_cursor) = highlighted_line;
 
-        let before_cursor_lines = before_cursor.lines();
-        let after_cursor_lines = after_cursor.lines();
+        let before_cursor_lines = before_cursor.split('\n');
+        let after_cursor_lines = after_cursor.split('\n');
 
         let mut commands = self
             .stdout


### PR DESCRIPTION
This fixes the rendering of a multiline where we end with a newline during a line continuation.